### PR TITLE
feat(mcp): add MCP server — query the collection from Claude Code, Cursor, Codex

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.env
+.env.local

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,106 @@
+# AI Pulse Georgia — MCP Server
+
+Query the [awesome-ai-pulse-georgia](https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia) curated collection (179+ AI repos across 9 categories) directly from inside Claude Code, Cursor, Codex, Claude.ai, or any other [Model Context Protocol](https://modelcontextprotocol.io)–compatible client.
+
+Instead of opening GitHub and scrolling through a README, ask your AI assistant:
+
+> "What's a good free Claude Code alternative?"
+> "Show me the top 5 RAG repos in this collection."
+> "Find browser automation tools written in TypeScript."
+
+The MCP server returns curated results from AI Pulse Georgia's hand-maintained list — every repo is vetted, categorized, and described in Georgian + English.
+
+---
+
+## Quick install
+
+The server is distributed as a Node CLI. Node 20+ is required.
+
+### Claude Code
+
+Add to your `~/.claude/claude_desktop_config.json` (or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "aipulsegeorgia": {
+      "command": "npx",
+      "args": ["-y", "@aipulsegeorgia/mcp-server"]
+    }
+  }
+}
+```
+
+Restart Claude Code. The 5 tools below appear under the `aipulsegeorgia` namespace.
+
+### Cursor
+
+Settings → MCP → Add new MCP server:
+
+```json
+{
+  "mcpServers": {
+    "aipulsegeorgia": {
+      "command": "npx",
+      "args": ["-y", "@aipulsegeorgia/mcp-server"]
+    }
+  }
+}
+```
+
+### Local development (this repo)
+
+```bash
+git clone https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia.git
+cd awesome-ai-pulse-georgia/mcp
+npm install
+npm run build
+node dist/index.js
+```
+
+Then point your client at the absolute path of `dist/index.js` instead of `npx`.
+
+---
+
+## Tools
+
+| Tool | Purpose | Example call |
+|------|---------|--------------|
+| `list_categories` | Show all 9 categories with repo counts | — |
+| `list_repos` | Browse by category, sort by stars or name, paginate | `{"category":"coding","limit":10}` |
+| `search_repos` | Full-text search across name + description | `{"query":"browser automation"}` |
+| `get_repo` | Fetch full details for a single repo | `{"name":"free-claude-code"}` |
+| `stats` | Total count + top 10 by stars | — |
+
+### Categories
+
+`coding` (🤖) · `plugins` (⚡) · `mcp` (🔌) · `scraping` (🕷️) · `frameworks` (🧬) · `business` (💼) · `memory` (🧠) · `infra` (⚙️) · `resources` (📚)
+
+---
+
+## How it works
+
+1. `scripts/build-data.ts` parses the root [`README.md`](../README.md) into a structured `data/repos.json` snapshot — that's the canonical source of truth.
+2. `src/index.ts` boots an MCP server on stdio and exposes the snapshot through 5 tools.
+3. The bundle is built with `tsup` and shipped as ESM targeting Node 20+.
+
+When the README is updated (new repo added, stars refreshed), running `npm run build` re-parses and rebuilds. The published npm version always reflects the latest README at publish time.
+
+---
+
+## Commands
+
+| Command | Effect |
+|---------|--------|
+| `npm run build:data` | Re-parse README → `data/repos.json` |
+| `npm run build` | Build data + compile bundle to `dist/` |
+| `npm run dev` | Run from source via `tsx` (no build step) |
+| `npm start` | Run the compiled bundle |
+
+---
+
+## License
+
+MIT — same as the parent collection. Contributions welcome via PR to the awesome-ai-pulse-georgia repo.
+
+Built by [AI Pulse Georgia](https://aipulsegeorgia.ge) 🇬🇪

--- a/mcp/data/repos.json
+++ b/mcp/data/repos.json
@@ -1,0 +1,1861 @@
+{
+  "generated": "2026-04-26T17:35:38.288Z",
+  "totalRepos": 179,
+  "categories": [
+    {
+      "slug": "coding",
+      "emoji": "🤖",
+      "english": "Coding Agents",
+      "georgian": "კოდინგ აგენტები",
+      "count": 23
+    },
+    {
+      "slug": "plugins",
+      "emoji": "⚡",
+      "english": "Claude Code Plugins & Skills",
+      "georgian": "Claude Code პლაგინები და უნარები",
+      "count": 24
+    },
+    {
+      "slug": "mcp",
+      "emoji": "🔌",
+      "english": "MCP Integrations",
+      "georgian": "MCP ინტეგრაციები",
+      "count": 23
+    },
+    {
+      "slug": "scraping",
+      "emoji": "🕷️",
+      "english": "Web Scraping & Browser",
+      "georgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "count": 15
+    },
+    {
+      "slug": "frameworks",
+      "emoji": "🧬",
+      "english": "AI Agent Frameworks",
+      "georgian": "AI აგენტების ფრეიმვორკები",
+      "count": 20
+    },
+    {
+      "slug": "business",
+      "emoji": "💼",
+      "english": "Ready-Made AI Agents for Business",
+      "georgian": "მზა AI აგენტები ბიზნესისთვის",
+      "count": 22
+    },
+    {
+      "slug": "memory",
+      "emoji": "🧠",
+      "english": "Memory & RAG",
+      "georgian": "მეხსიერება და RAG",
+      "count": 15
+    },
+    {
+      "slug": "infra",
+      "emoji": "⚙️",
+      "english": "AI Infrastructure & Tools",
+      "georgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "count": 24
+    },
+    {
+      "slug": "resources",
+      "emoji": "📚",
+      "english": "Resources & Learning",
+      "georgian": "რესურსები და სასწავლო მასალები",
+      "count": 13
+    }
+  ],
+  "repos": [
+    {
+      "name": "Claw Code",
+      "url": "https://github.com/ultraworkers/claw-code",
+      "stars": "187K",
+      "description": "Claw Code არის Claude Code-ისა და სხვა კომერციული coding agent-ების ღია კოდის ალტერნატივა, Rust-ში დაწერილი `oh-my-codex`-ის ბაზაზე. მუშაობს Claude-თან, OpenAI-თან, Grok-თან და ნებისმიერ OpenAI-თავსებად მოდელ API-სთან — შენ ირჩევ რომელ AI-ს ენდობი და რამდენს იხდი. Rust-ის არქიტექტურა მაქსიმალურ სიჩქარეს უზრუნველყოფს და რესურსების მინიმალურ მოხმარებას. 2026 წლის 31 მარტს გამოიცა და 24 აპრილისთვის უკვე **187,000+ ვარსკვლავი** დააგროვა — ერთ-ერთი ყველაზე სწრაფად მზარდი AI ხელსაწყო GitHub-ის ისტორიაში.",
+      "starsNumeric": 187000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "opencode",
+      "url": "https://github.com/anomalyco/opencode",
+      "stars": "148K",
+      "description": "opencode სრულად ღია კოდის coding agent-ია ტერმინალში — Claude Code-ისა და Cursor-ის უფასო, self-hosted ალტერნატივა. `anomalyco` org-ის მიერ შენახული, TypeScript-ში დაწერილი, ლამაზი TUI ინტერფეისით. ნებისმიერი AI მოდელით მუშაობს — Anthropic, OpenAI, Google Gemini, Ollama და სხვა. 148,000+ ვარსკვლავით ერთ-ერთი ყველაზე პოპულარული ღია coding agent-ია 2025 წლის მეორე ნახევრიდან.",
+      "starsNumeric": 148000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Gemini CLI",
+      "url": "https://github.com/google-gemini/gemini-cli",
+      "stars": "102K",
+      "description": "Gemini CLI არის Google-ის ოფიციალური, ღია კოდის AI კოდირების აგენტი ტერმინალისთვის — Gemini 2.5 Pro მოდელი პირდაპირ შენს command line-ში. 1 მილიონი ტოკენის კონტექსტის ფანჯარა ნიშნავს, რომ მთელი დიდი კოდბაზა ერთიანად ჩაიტვირთება. Apache 2.0 ლიცენზიით სრულად უფასოა, MCP პროტოკოლს და Google Workspace ინტეგრაციებს უჭერს მხარს. Google-ს Claude Code-ისა და opencode-ის საპასუხო, ოფიციალური შეთავაზება.",
+      "starsNumeric": 102000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Codex CLI",
+      "url": "https://github.com/openai/codex",
+      "stars": "77K",
+      "description": "Codex CLI არის OpenAI-ის ოფიციალური, მსუბუქი coding agent ტერმინალისთვის — Rust-ში დაწერილია სიჩქარისა და სტაბილურობისთვის. კოდს sandbox-ში იზოლირებულად ასრულებს, approval-mode ფლაგებით შეგიძლია ზუსტად განსაზღვრო რა ნებართვები აქვს. ChatGPT-ის ანგარიშით (Plus, Pro, Business, Edu ან Enterprise) პირდაპირ ავტორიზდები — ცალკე API key-ის გარეშე იმდენივე მოდელი გაქვს, რამდენსაც შენი გამოწერა მოიცავს. OpenAI-ის პირდაპირი პასუხი Claude Code-ზე — ანალოგიური ფილოსოფია, სხვა backend-ით. დამატებით `codex app` გრაფიკულ ვერსიასაც უშვებს.",
+      "starsNumeric": 77000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "OpenHands",
+      "url": "https://github.com/All-Hands-AI/OpenHands",
+      "stars": "71K",
+      "description": "OpenHands (ყოფილი OpenDevin) ავტონომიური AI სოფტვერ-ინჟინერია — ქმნის და რედაქტირებს ფაილებს, ასრულებს shell ბრძანებებს, ვებ ბრაუზერს იყენებს და API-ებს უძახებს, ადამიანის ჩარევის გარეშე. Docker კონტეინერში იზოლირებულად მუშაობს, ვებ UI-ითაც და CLI-ითაც. 200-ზე მეტი contributor-ი, 60+ LLM backend (Anthropic, OpenAI, Gemini, Ollama) — SWE-bench-ის ღია კოდის ბენჩმარკ-ლიდერი. Cognition AI-ის Devin-ის ღია ალტერნატივა Python-ში.",
+      "starsNumeric": 71000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Cline",
+      "url": "https://github.com/cline/cline",
+      "stars": "60K",
+      "description": "Cline VS Code-ში ჩაშენებული ავტონომიური coding agent-ია, რომელიც ყოველ ნაბიჯზე შენს ნებართვას ითხოვს — ვერც ერთ ფაილს ვერ შეცვლის და ვერც ერთ ბრძანებას ვერ გაუშვებს შენი დამტკიცების გარეშე. ფაილების შექმნა, რედაქტირება, ბრძანებების გაშვება, ბრაუზერის გამოყენება — ყველაფერი ერთ IDE-ში. TypeScript-ში დაწერილია, VS Code extension-ის სახით 5 მილიონზე მეტი ინსტალაცია აქვს, Claude, GPT, Gemini და 500+ LLM-ს უჭერს მხარს.",
+      "starsNumeric": 60000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "omo (ex-oh-my-openagent)",
+      "url": "https://github.com/code-yeongyu/oh-my-openagent",
+      "stars": "53K",
+      "description": "omo (**ახლანდელი სახელი**; ადრე oh-my-openagent, უფრო ადრე oh-my-opencode) ერთი AI coding session-ს სრულ multi-agent სისტემად აქცევს — სპეციალიზებული AI-ები პარალელურად ასრულებენ სხვადასხვა ამოცანებს ერთ workflow-ში. TypeScript-ში დაწერილი orchestration framework, რომელიც Claude Code-თან, Codex-თან, opencode-თან და Cursor-თან მუშაობს. Oh My ClaudeCode-ისგან სრულიად განსხვავებული პროექტია — ეს ზოგადი agent harness-ია, ის კი Claude Code-სპეციფიკური. 53,000+ ვარსკვლავი, 2025 წლის ბოლოს გამოჩნდა (repo URL ჯერ ძველ სახელს ინახავს).",
+      "starsNumeric": 53000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Aider",
+      "url": "https://github.com/Aider-AI/aider",
+      "stars": "43K",
+      "description": "Aider ტერმინალის AI pair programming ხელსაწყოა — ერთ-ერთი პიონერი ამ სფეროში, 2023 წლიდან. უბრალოდ სთხოვ რა გინდა შეცვალო, Aider საჭირო ფაილებს თავადვე ხსნის, კოდს ასწორებს და git-ში commit-ს ქმნის. Python-ში დაწერილია, MIT ლიცენზიით სრულად ღია, 4 მილიონზე მეტი ინსტალაცია. Claude, GPT, Gemini, DeepSeek, Ollama და 100+ LLM-ს უჭერს მხარს — ყველა მთავარი frontier მოდელი და ლოკალური ოფციები. უნივერსალური, ძველი და სანდო.",
+      "starsNumeric": 43000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Goose",
+      "url": "https://github.com/aaif-goose/goose",
+      "stars": "43K",
+      "description": "Goose ღია კოდის, გაფართოებადი AI agent-ია. თავდაპირველად Block-ის (Square/Cash App-ის ფინტექ კომპანია) შექმნილი, 2026-ში პროექტი **Agentic AI Foundation**-ში (Linux Foundation) გადავიდა — სახელი და ოფიციალური owner ახლა `aaif-goose`, კოდი neutral governance-ქვეშ. კოდის წერის მიღმა სრული სამუშაო ციკლი — ინსტალაცია, გაშვება, ტესტირება, მონაცემთა ანალიზი და ავტომატიზაცია. Rust-ში დაწერილია, 15+ AI პროვაიდერს (Anthropic, OpenAI, Google, Ollama) და 70+ MCP გაფართოებას უჭერს მხარს.",
+      "starsNumeric": 43000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Tabby",
+      "url": "https://github.com/TabbyML/tabby",
+      "stars": "33K",
+      "description": "Tabby AI-ის კოდირების ასისტენტია, რომელიც შენს საკუთარ სერვერზე ეშვება — GitHub Copilot-ის self-hosted, ღია ალტერნატივა. კოდის auto-completion და ჩატი VS Code-ში, JetBrains-ში და სხვა IDE-ებში. Rust-ში დაწერილია, OpenAPI ინტერფეისი, LDAP/SSO, პერსონალიზებული fine-tuning — კორპორატიული გამოყენებისთვის, სადაც კოდი კომპანიის სერვერს ვერ ტოვებს. MIT ლიცენზია.",
+      "starsNumeric": 33000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Continue.dev",
+      "url": "https://github.com/continuedev/continue",
+      "stars": "32K",
+      "description": "Continue ღია კოდის AI კოდირების გაფართოებაა VS Code-ისა და JetBrains-ისთვის. ნებისმიერი AI მოდელი — Claude, GPT, Gemini, Mistral, Ollama ლოკალური მოდელები — ერთ ინტერფეისში. chat, autocomplete, edit და agent რეჟიმები, CI-ში ჩართვადი AI checks. TypeScript-ში დაწერილია, სრულად კონფიგურირებადი, 30,000+ ვარსკვლავი. გამოწერა არ სჭირდება — Copilot-ის უფასო ალტერნატივა.",
+      "starsNumeric": 32000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Void",
+      "url": "https://github.com/voideditor/void",
+      "stars": "28K",
+      "description": "Void VS Code-ის ღია კოდის fork-ია, რომელიც AI-ს IDE-ის გულში სვამს — Cursor-ის ღია ალტერნატივა. Tab completion, agent mode, inline edit — Cursor-ის ძირითადი ფუნქციები სრული კოდის კონტროლით. self-hosted LLM-ებს უჭერს მხარს (Ollama, vLLM), ასე რომ მონაცემები შენს მანქანაზე რჩება. **მნიშვნელოვანი**: 2026-ში გუნდმა IDE-ის აქტიური განვითარება შეაჩერა („paused\") ახალი coding idea-ების შესასწავლად — repo ცოცხალია, მაგრამ Issues/PRs-ის აქტიური review არ ხდება. ფუნქციონირებს, მაგრამ feature drift მოსალოდნელია. TypeScript-ში, MIT ლიცენზია.",
+      "starsNumeric": 28000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "GitNexus",
+      "url": "https://github.com/abhigyanpatwari/GitNexus",
+      "stars": "28K",
+      "description": "GitNexus — ბრაუზერში სრულად მომუშავე კოდის ინტელიჯენსის ხელსაწყო, სერვერის გარეშე. GitHub-ის repo ან ZIP ჩააგდე და ნახავ ყველა ფაილს, ფუნქციასა და მათ ურთიერთდამოკიდებლობას ინტერაქტიული knowledge graph-ის სახით. ჩაშენებული Graph RAG Agent ამ graph-ს იყენებს, რომ კოდზე ბუნებრივ ენაზე დასმულ კითხვებს უპასუხოს. TypeScript-ში დაწერილი, სრულად client-side, backend deploy-ი არ სჭირდება. კოდის კომპლექსური ბაზის სწრაფი გასაგებად გამოსადეგია.",
+      "starsNumeric": 28000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Taskmaster",
+      "url": "https://github.com/eyaltoledano/claude-task-master",
+      "stars": "26K",
+      "description": "Taskmaster AI-ზე დაფუძნებული პროექტის მართვის სისტემაა — დიდ ამოცანას ავტომატურად ანაწილებს მართვად ქვე-ამოცანებად, გაწერს პრიორიტეტებს, ადევნებს პროგრესსა და კონტექსტს. Cursor-ში, Windsurf-ში, Lovable-ში, Roo-ში და Claude Code-ში ჩასმა MCP სერვერის ან CLI-ის სახით. JavaScript-ში დაწერილია, tryhamster.com — AI-ის „პროდაქტ მენეჯერი\" კომპლექსური სამუშაო ნაკადებისთვის.",
+      "starsNumeric": 26000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "OpenClaude",
+      "url": "https://github.com/Gitlawb/openclaude",
+      "stars": "23K",
+      "description": "OpenClaude ღია კოდის terminal coding agent-ია, რომელიც 200+ AI მოდელს ერთი CLI ინტერფეისიდან ხდის ხელმისაწვდომს — OpenAI, Gemini, DeepSeek, Ollama, Codex, GitHub Models. TypeScript-ში დაწერილია, OpenAI-თავსებადი API სტანდარტზე. 2026 წლის აპრილში გამოჩნდა და სწრაფად გაიზარდა. Claw Code-ისგან სხვაობა: ეს ფოკუსირებულია მრავალი provider-ის მხარდაჭერაზე, ის კი სიჩქარეზე. (არ აერიოს OpenHands-ში — სრულიად განსხვავებული პროექტია.)",
+      "starsNumeric": 23000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Qwen Code",
+      "url": "https://github.com/QwenLM/qwen-code",
+      "stars": "23K",
+      "description": "Qwen Code Alibaba-ს Qwen გუნდის ოფიციალური, ღია კოდის terminal coding agent-ია. TypeScript-ში დაწერილი, OpenAI-თავსებადი API-ის სტანდარტით მუშაობს — ანუ Anthropic-ის, OpenAI-ის და Google-ის მოდელებიც ჩართულია. Qwen 3 მოდელებით განსაკუთრებით კარგია კოდბაზის ნავიგაციასა და ავტომატიზაციაში. Claude Code-ისა და Gemini CLI-ის კონკურენტი Alibaba-ს ეკოსისტემიდან.",
+      "starsNumeric": 23000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Roo Code",
+      "url": "https://github.com/RooCodeInc/Roo-Code",
+      "stars": "23K",
+      "description": "Roo Code VS Code-ის გაფართოებაა, რომელიც AI coding agent-ების მთელ გუნდს გაძლევს editor-ში. Cline-ის fork-ია, მაგრამ ბევრად მეტი ფუნქციით — custom agent modes, პარალელური multi-agent სამუშაო, ფართო MCP მხარდაჭერა. 500+ LLM provider, 1.5 მილიონზე მეტი ინსტალაცია. TypeScript, Apache 2.0 ლიცენზია, ძალიან აქტიური განვითარება.",
+      "starsNumeric": 23000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Kilocode",
+      "url": "https://github.com/kilo-org/kilocode",
+      "stars": "18K",
+      "description": "Kilocode VS Code-ის AI coding agent-ია, kilo.ai-ის agentic engineering platform-ის ღია კოდის გული. 500+ AI მოდელს უჭერს მხარს, ბუნებრივი ენის ბრძანებებით კოდს წერს, ტესტავს და deploy-ს. TypeScript, 1.5 მილიონზე მეტი ინსტალაცია. OpenRouter-ის coding agent-ების სიაში წამყვანი — Roo Code-ისა და Cline-ის პირდაპირი კონკურენტი.",
+      "starsNumeric": 18000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Codex Plugin",
+      "url": "https://github.com/openai/codex-plugin-cc",
+      "stars": "15K",
+      "description": "Codex Plugin არის OpenAI-ის ოფიციალური Claude Code plugin — Codex CLI-ის agent-ს Claude Code-ის შიგნიდან გამოძახების საშუალებას გაძლევს. კოდის review-ისა და ამოცანების დელეგირებისთვის — OpenAI-ს Codex-ი და Anthropic-ს Claude Code ერთ workflow-ში. JavaScript, 2026 წლის მარტიდან ხელმისაწვდომია. ცალკე რეპოა openai/codex CLI-სგან (რომელიც terminal agent-ია — ეს კი Claude Code-ის plugin-ია).",
+      "starsNumeric": 15000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "cmux",
+      "url": "https://github.com/manaflow-ai/cmux",
+      "stars": "15K",
+      "description": "cmux Ghostty-ს საფუძველზე აშენებული macOS terminal emulator-ია, სპეციალურად AI coding agent-ებისთვის ოპტიმიზებული. ვერტიკალური tabs, push notifications და პარალელური სესიების მარტივი მართვა — თუ ერთდროულად რამდენიმე AI agent-ს ამუშავებ (Claude Code + Codex + opencode), ეს terminal-ი სამართავს გამარტივებს. Swift-ში დაწერილია, macOS-only.",
+      "starsNumeric": 15000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "free-claude-code",
+      "url": "https://github.com/Alishahryar1/free-claude-code",
+      "stars": "11K",
+      "description": "free-claude-code ღია კოდის ხელსაწყოა Claude Code-ის უფასოდ გამოყენების სამი არხით — ტერმინალში, VS Code გაფართოებად ან Discord bot-ით. სამი ინტერფეისი ერთ პაკეტში: ლოკალურად კოდის წერისას CLI/IDE, გუნდურ მუშაობაზე Discord-ით. Python-ში დაწერილია, MIT ლიცენზია, 2026 წლის იანვრიდან 11,000+ ვარსკვლავი დააგროვა.",
+      "starsNumeric": 11000,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "ml-intern",
+      "url": "https://github.com/huggingface/ml-intern",
+      "stars": "4.2K",
+      "description": "ml-intern არის **Hugging Face-ის ოფიციალური** ღია კოდის AI-ML ინჟინერი — ავტონომიური აგენტი, რომელიც კვლევის ნაშრომებს კითხულობს (arXiv), ML მოდელებს ტრენინგს უწევს და ship-ს აკეთებს Hugging Face Hub-ზე. Python-ში, OpenAI/Anthropic API ან ლოკალური მოდელებით მუშაობს. **2026 წლის 24 აპრილის GitHub Trending #1** — +720 ვარსკვლავი ერთ დღეში. ML research-ის ავტომატიზაციით დაინტერესებულ მკვლევართათვის — პერპეტუალური ML intern.",
+      "starsNumeric": 4200,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Open Agents",
+      "url": "https://github.com/vercel-labs/open-agents",
+      "stars": "4.1K",
+      "description": "Open Agents არის Vercel Labs-ის ღია კოდის reference template ღრუბლოვანი AI agent-ების ასაშენებლად. agent VM sandbox-ში ეშვება, GitHub-ს ინტეგრაცია, workflow runtime და ჩაშენებული ვებ-ინტერფეისი შედის. TypeScript-ში, Vercel-ზე ადვილად დეპლოისებადი. ლოკალური კომპიუტერის გარეშე ფონური coding agent-ებისთვის — reference implementation, არა production-ready პლატფორმა.",
+      "starsNumeric": 4100,
+      "categorySlug": "coding",
+      "categoryEmoji": "🤖",
+      "categoryGeorgian": "კოდინგ აგენტები"
+    },
+    {
+      "name": "Superpowers",
+      "url": "https://github.com/obra/superpowers",
+      "stars": "165K",
+      "description": "Superpowers agentic skills framework-ია AI coding agent-ებისთვის — software development methodology, რომელიც AI-ს „ჯერ დაფიქრდი, მერე დაწერე\" პრინციპს ასწავლის. სანამ კოდი ეწერება, ჯერ სპეციფიკაცია, დიზაინ დოკუმენტი და test plan იქმნება. Claude Code-ს, Codex-ს, Cursor-ს და Gemini CLI-ს უჭერს მხარს. Shell scripts, MIT ლიცენზია, 165,000+ ვარსკვლავი. Spec Kit-ის (GitHub-ისა) და GSD-ის იდეური წინამორბედი.",
+      "starsNumeric": 165000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Everything Claude Code",
+      "url": "https://github.com/affaan-m/everything-claude-code",
+      "stars": "165K",
+      "description": "Everything Claude Code Claude Code-ის, Codex-ის, opencode-ისა და Cursor-ის ყოვლისმომცველი performance optimization სისტემაა — skills, memory, security scanning და research-first workflow ერთ პაკეტში. JavaScript, ecc.tools — ყველაზე პოპულარული Claude Code enhancement collection 165,000+ ვარსკვლავით. AI-ს „ინსტინქტების\" (instincts) სისტემა განასხვავებს სხვა skill-pack-ებისგან — agent-ი ავტომატურად ადაპტირდება სიტუაციებზე წინასწარ განსაზღვრული behavior-ებით.",
+      "starsNumeric": 165000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Spec Kit",
+      "url": "https://github.com/github/spec-kit",
+      "stars": "90K",
+      "description": "Spec Kit GitHub-ის ოფიციალური Spec-Driven Development toolkit-ია — AI-ს „ჯერ გეგმა, მერე კოდი\" პრინციპს ასწავლის. `/specify`, `/plan`, `/tasks`, `/implement` slash-commands-ით AI ჯერ სრულ სპეციფიკაციას ქმნის, შემდეგ კი კოდირებაზე გადადის. Claude Code-ს, Codex CLI-ს, Gemini CLI-ს, Cursor-ს, Copilot-ს, Windsurf-ს და Qwen Code-ს უჭერს მხარს. GitHub-ის ოფიციალური პასუხი Superpowers-ისა და GSD-ის მსგავს მეთოდოლოგიებზე — 90,000+ ვარსკვლავი.",
+      "starsNumeric": 90000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Karpathy Skills",
+      "url": "https://github.com/forrestchang/andrej-karpathy-skills",
+      "stars": "80K",
+      "description": "Karpathy Skills ერთი CLAUDE.md ფაილია, რომელიც Andrej Karpathy-ს (OpenAI-ისა და Tesla AI-ს ყოფილი ხელმძღვანელი) LLM coding pitfalls-ის შენიშვნებიდანაა გამომდინარე. AI-ს ჰალუცინაციებს, ზედმეტ refactoring-ს და ცუდ debugging-ს ებრძვის წინასწარ განსაზღვრული rules-ით. Forrest Chang-ის მიერ შექმნილი 2026 წლის იანვარში — 80,000+ ვარსკვლავი, GitHub Trending-ზე #1-ზე ყოფნა. Andrej Karpathy-ს სახელი ატარებს, მაგრამ მის მიერ ოფიციალურად შექმნილი არ არის.",
+      "starsNumeric": 80000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "UI UX Pro Max",
+      "url": "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill",
+      "stars": "69K",
+      "description": "UI UX Pro Max AI coding agent-ებს professional UI/UX დიზაინის ინტელიგენციას სძენს — 50 დიზაინ სტილი, 161 ფერთა პალიტრა და 25 დიაგრამის ტიპი ერთ skill-ში. React-ს, Vue-ს, Flutter-ს, SwiftUI-ს და სხვა ფრეიმვორკებს უჭერს მხარს. Python-ში, 69,000+ ვარსკვლავი — Claude Code-ის, Cursor-ის და სხვა agent-ების visual output-ს მნიშვნელოვნად აუმჯობესებს. დიზაინერის გარეშე ლამაზი UI-ის ასაშენებლად.",
+      "starsNumeric": 69000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Claude Mem",
+      "url": "https://github.com/thedotmack/claude-mem",
+      "stars": "66K",
+      "description": "Claude Mem Claude Code-ის მეხსიერების plugin-ია — ავტომატურად ჩაწერს რასაც Claude coding session-ში აკეთებს, Claude-ის agent SDK-ით კომპრესსავს და შემდეგ session-ში რელევანტურ კონტექსტს უბრუნებს. TypeScript-ში, claude-mem.ai. ანუ ყოველ ჯერზე ხელახლა ახსნა აღარ სჭირდება — Claude „ახსოვს\" რაზე მუშაობდი. 66,000+ ვარსკვლავი.",
+      "starsNumeric": 66000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "GSD (Get Shit Done)",
+      "url": "https://github.com/gsd-build/get-shit-done",
+      "stars": "56K",
+      "description": "GSD (Get Shit Done) meta-prompting და context engineering სისტემაა Claude Code-ისთვის TÂCHES-ის მიერ. სპეციალური specification ფაილებით AI-ის კონტექსტი სტრუქტურირებულად ინახება — session-ებს შორისაც, რაც ხარისხის ვარდნის პრობლემას წყვეტს. Claude Code-ს, Codex-ს, Cursor-ს და Gemini CLI-ს უჭერს მხარს. JavaScript, 56,000+ ვარსკვლავი — spec-driven development-ის პრაქტიკული implementation Superpowers-ისა და Spec Kit-ის ალტერნატივა.",
+      "starsNumeric": 56000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Caveman",
+      "url": "https://github.com/JuliusBrussee/caveman",
+      "stars": "44K",
+      "description": "Caveman Claude Code-ის (და სხვა agent-ების) ტოკენების მოხმარებას 65%-ით ამცირებს — AI-ს ასწავლის „გამოქვაბულის ადამიანივით\" ლაპარაკს, ზედმეტი სიტყვების გამოტოვებით. ხარისხი არ ეცემა, მხოლოდ verbosity მცირდება. Lite, Full და Ultra ინტენსივობის დონეები. Python-ში, Julius Brussee-ის მიერ. 40+ coding agent-ს უჭერს მხარს (Claude Code, Codex, Gemini CLI, Cursor). 2026 წლის აპრილში გამოჩნდა, 44,000+ ვარსკვლავი — AI ხარჯების შემამცირებელი ყველაზე პოპულარული skill.",
+      "starsNumeric": 44000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Career-Ops",
+      "url": "https://github.com/santifer/career-ops",
+      "stars": "38K",
+      "description": "Career-Ops Claude Code-ზე აგებული AI-ს სამუშაოს ძიების სისტემაა — 14 skill mode, Go-ში დაწერილი dashboard, PDF CV გენერაცია და batch processing ვაკანსიების ავტომატური შეფასებისთვის. ვაკანსიების პოვნა, A-F სკალით შეფასება, CV-ს პოზიციაზე მორგება. JavaScript, career-ops.org. 38,000+ ვარსკვლავი — AI-ს job search-ზე გამოყენების ერთ-ერთი ყველაზე სრული open-source implementation.",
+      "starsNumeric": 38000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Graphify",
+      "url": "https://github.com/safishamsi/graphify",
+      "stars": "33K",
+      "description": "Graphify კოდის, დოკუმენტაციის, PDF-ების, სურათების და ვიდეოების queryable knowledge graph-ად გარდაქმნის AI coding agent-ებისთვის. Claude Code-ს, Codex-ს, opencode-ს, Cursor-ს, Gemini CLI-ს და სხვებს უჭერს მხარს. Python-ში, graphifylabs.ai. Graph-ზე დაფუძნებული კითხვების მეთოდი AI-ის ტოკენებს 71-ჯერ ამცირებს ფაილების პირდაპირ კითხვასთან შედარებით. 33,000+ ვარსკვლავი — 2026 წლის აპრილში სწრაფად გაიზარდა.",
+      "starsNumeric": 33000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "RuFlo (ex-Claude Flow)",
+      "url": "https://github.com/ruvnet/claude-flow",
+      "stars": "33K",
+      "description": "RuFlo v3.5 (ყოფილი **Claude Flow**; repo URL ჯერ ძველ სახელს ინახავს) Enterprise AI Orchestration Platform-ია — „distributed swarm intelligence\" მიდგომით რამდენიმე AI agent პარალელურად ასრულებს ერთ workflow-ს. RAG ინტეგრაცია, native Claude Code + Codex მხარდაჭერა, enterprise-დონის არქიტექტურა. TypeScript-ში, `ruvnet` (ruv.io) platform-ის ნაწილი. 33,000+ ვარსკვლავი — ერთ-ერთი ყველაზე ფუნქციონალური multi-agent orchestration ხელსაწყო Claude Code ეკოსისტემაში.",
+      "starsNumeric": 33000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Oh My ClaudeCode",
+      "url": "https://github.com/yeachan-heo/oh-my-claudecode",
+      "stars": "30K",
+      "description": "Oh My ClaudeCode Claude Code-ს multi-agent orchestration სისტემად აქცევს — autopilot რეჟიმში ავტონომიურად მუშაობს 5-ფაზიანი pipeline-ით (Expansion, Planning, Execution, QA, Validation), team რეჟიმში კი N agent-ი პარალელურად ასრულებს ამოცანებს. TypeScript-ში, 19 სპეციალიზებული agent, 36 skill. oh-my-openagent-ისგან განსხვავება: ეს Claude Code-სპეციფიკური orchestration-ია, ის კი ზოგადი agent harness. 30,000+ ვარსკვლავი.",
+      "starsNumeric": 30000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Obsidian Skills",
+      "url": "https://github.com/kepano/obsidian-skills",
+      "stars": "26K",
+      "description": "Obsidian Skills Obsidian-ის CEO-ს, Steph Ango-ს (kepano) მიერ შექმნილი agent skills პაკეტია. AI coding agent-ებს ასწავლის Obsidian-ის Markdown ფორმატს, Bases მონაცემთა სტრუქტურას, JSON Canvas-ს და CLI-ს. Claude Code, Codex ან ნებისმიერი MCP-თავსებადი agent Obsidian vault-ში ფაილების შექმნას, ძიებასა და რედაქტირებას შეძლებს. Obsidian-ს იყენებ ცოდნის ბაზად? ეს skill-ი AI-ს ამ ბაზაში მუშაობის ექსპერტად აქცევს.",
+      "starsNumeric": 26000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "last30days-skill",
+      "url": "https://github.com/mvanhorn/last30days-skill",
+      "stars": "23.8K",
+      "description": "last30days-skill Claude Code/Codex skill-ია, რომელიც ერთ ბრძანებაში ნებისმიერი თემის სრულ კვლევას აკეთებს — **Reddit, X/Twitter, YouTube, Hacker News, Polymarket** და ვები პარალელურად დამუშავდება და **grounded summary** მიიღება წყაროებით. Python-ში, 2026 წლის იანვრიდან 23.8K+ ვარსკვლავი დააგროვა. **2026 აპრილის ტოპ-ტრენდული Claude Code skill-ებიდან** — competitive analysis, trend research, product research-ისთვის იდეალური. AI Pulse Georgia-ს მიგნებებისთვის — ქართული ჟურნალისტიკის, SMM-ის და product კვლევის acceleratore.",
+      "starsNumeric": 23800,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Agent Skills",
+      "url": "https://github.com/addyosmani/agent-skills",
+      "stars": "21K",
+      "description": "Agent Skills Google-ის Chrome DevRel-ის ხელმძღვანელის Addy Osmani-ს production-grade engineering skills კოლექციაა AI coding agent-ებისთვის. 20+ Markdown workflow — spec-driven development, TDD, code review, shipping და სხვა — agent-ს senior engineer-ის მიდგომებს ასწავლის. Shell-ში, 21,000+ ვარსკვლავი. Agent Skills Spec-ისგან განსხვავება: ეს Osmani-ს კონკრეტული skill-ების კოლექციაა, ის კი ფართო სპეციფიკაციის სტანდარტია.",
+      "starsNumeric": 21000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Claude Plugins Official",
+      "url": "https://github.com/anthropics/claude-plugins-official",
+      "stars": "17K",
+      "description": "Claude Plugins Official Anthropic-მართული Claude Code Plugin-ების ოფიციალური კატალოგია — მხოლოდ შემოწმებული, მაღალი ხარისხის plugin-ები. Python-ში, code.claude.com/docs-ის ლინკი. GitHub org-ი `anthropics` (note: Anthropic-ის ძირითადი org-ი ჩვეულებრივ `anthropic` ეწოდება — plugin-ის ინსტალაციამდე დამოუკიდებლად შეამოწმე ოფიციალურობა). 17,000+ ვარსკვლავი.",
+      "starsNumeric": 17000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Agent Skills Spec",
+      "url": "https://github.com/agentskills/agentskills",
+      "stars": "16K",
+      "description": "Agent Skills Spec AI agent-ებისთვის skills-ის მიცემის ღია სტანდარტისა და სპეციფიკაციის კოლექციაა — write-once, use-everywhere პრინციპით. სრული სპეციფიკაციის დოკუმენტი, reference SDK და მაგალითი skill-ები. Python-ში, agentskills.io — დამოუკიდებელი, community-driven პროექტი. Claude Code, Codex და სხვა platform-ები ამ სტანდარტს მიჰყვებიან, თუმცა ეს Anthropic-ის ოფიციალური სტანდარტი არ არის.",
+      "starsNumeric": 16000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Claude Code Game Studios",
+      "url": "https://github.com/Donchitos/Claude-Code-Game-Studios",
+      "stars": "16K",
+      "description": "Claude Code Game Studios Claude Code-ს სრულფასოვან თამაშების სტუდიად აქცევს — **49 AI აგენტი და 72 workflow skill**, ნამდვილი game development სტუდიის იერარქიის ანარეკლი. Producer, Designer, Artist, Programmer, QA Tester როლებში სპეციალიზებული agent-ები ერთობლივად მუშაობენ ვიდეო თამაშების შესაქმნელად. Shell-ში, 2026 წლის თებერვლიდან 16K ვარსკვლავი დააგროვა. game dev-ის Claude Code-ზე აწყობის ერთ-ერთი ყველაზე მასშტაბური setup — ქართული indie გუნდებისთვის მზა workflow-ები.",
+      "starsNumeric": 16000,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "n8n Skills",
+      "url": "https://github.com/czlonkowski/n8n-skills",
+      "stars": "4.6K",
+      "description": "n8n Skills Claude Code-ს n8n ავტომატიზაციის ექსპერტად აქცევს — 7 ურთიერთშემავსებელი skill, 525+ n8n node-ის ცოდნა, 2,653+ კონფიგურაციის მაგალითი. Shell-ში, n8n-skills.com. n8n-MCP-სთან (ასევე ამ კოლექციაში) ერთად გამოყენება კიდევ უფრო ძლიერ workflow-ების საშენებლად. n8n workflow-ებს AI-ით ავტომატურად ვინც ქმნის, ეს skill-ი აუცილებელია.",
+      "starsNumeric": 4600,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Architecture Diagram Generator",
+      "url": "https://github.com/Cocoon-AI/architecture-diagram-generator",
+      "stars": "4.3K",
+      "description": "Architecture Diagram Generator Claude AI-ის skill-ია, რომელიც ტექსტური სისტემის აღწერიდან standalone HTML/SVG დიაგრამებს ქმნის — dark theme-ით, ფერების სემანტიკური კოდირებით (cyan: frontend, emerald: backend, violet: databases, amber: cloud, rose: security). HTML-ში, Cocoon-AI-ის მიერ. დიზაინის ცოდნა არ სჭირდება — სისტემის ბუნებრივ ენაში აღწერა საკმარისია. 4,000+ ვარსკვლავი.",
+      "starsNumeric": 4300,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Remotion Skills",
+      "url": "https://github.com/remotion-dev/skills",
+      "stars": "2.9K",
+      "description": "Remotion Skills Remotion-ის (React-ში ვიდეოების პროგრამული შექმნის ფრეიმვორკი) ოფიციალური agent skills-ია. AI coding agent-ებს Remotion-ის ექსპერტიზას სძენს — კომპოზიცია, რენდერინგი, ტაიმინგი, animation. TypeScript-ში. თუ data visualizations-ს, reels-ს ან ანიმაციებს React კომპონენტებიდან ქმნი, ეს skill-ი AI-ს ყველა ნიუანსს ასწავლის — Remotion-ის ოფიციალური გუნდის მიერ.",
+      "starsNumeric": 2900,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Headroom",
+      "url": "https://github.com/chopratejas/headroom",
+      "stars": "1.5K",
+      "description": "Headroom LLM აპლიკაციებისთვის context optimization layer-ია — AI-ს გადასაცემ მონაცემებს (ფაილები, ლოგები, RAG შედეგები) 70-95%-ით ამცირებს პასუხის ხარისხის დაკარგვის გარეშე. Python-ში, headroom-docs.vercel.app. Claude Code-ში, Codex-ში და Aider-ში ერთი ბრძანებით ეშვება. AI ხარჯების მნიშვნელოვნად შემცირებისა და უფრო გრძელი სამუშაო სესიების შესაძლებლობისთვის — 1,500+ ვარსკვლავი.",
+      "starsNumeric": 1500,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Claude Code Setup",
+      "url": "https://github.com/tornikebolokadze1-cyber/claude-code-setup",
+      "stars": "9",
+      "description": "Claude Code Setup Claude Code-ის production-grade კონფიგურაციაა — 17 წესი, 7 hook, 7 შაბლონი და /setup ბრძანება ახალი პროექტებისთვის. ერთი ინსტალაციით: უსაფრთხოების წესები, ავტომატური ტესტირება, CI/CD ინტეგრაცია, საიდუმლოებების დაცვა. TypeScript-ში, საქართველოში შექმნილი. 9 ვარსკვლავი — ახალი, ლოკალური პროექტი, production-ში განვითარების ეტაპზეა.",
+      "starsNumeric": 9,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "Georgian Payments Skills",
+      "url": "https://github.com/erekle1/georgian-payments-skills",
+      "stars": "7",
+      "description": "Georgian Payments Skills ქართული საბანკო API-ების ცოდნას AI ასისტენტებს სძენს — TBC Bank-ის (Checkout, TPay) და Bank of Georgia-ს (iPay, Installments, Open Banking) ინტეგრაციები. Python-ში, საქართველოში შექმნილი. ქართულ საგადახდო სისტემებთან მომუშავე დეველოპერებისთვის — AI-ს ექსპერტ-დონის ლოკალური ცოდნა, რომელიც სხვაგან არ არსებობს. 7 ვარსკვლავი — ახალი ლოკალური resource.",
+      "starsNumeric": 7,
+      "categorySlug": "plugins",
+      "categoryEmoji": "⚡",
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+    },
+    {
+      "name": "MCP Servers",
+      "url": "https://github.com/modelcontextprotocol/servers",
+      "stars": "84K",
+      "description": "MCP Servers Model Context Protocol-ის ოფიციალური სერვერების მონორეპოა — ეს MCP ეკოსისტემის ფუნდამენტი და reference implementation. ფაილების სისტემა, Git, Slack, memory, browser automation — ათობით built-in server ერთ ადგილას. 10 პროგრამირების ენის SDK (TypeScript, Python, Go, Rust, Java და სხვა). Anthropic-ის მიერ შენახული, Apache 2.0 ლიცენზია. 84,000+ ვარსკვლავი — ნებისმიერი MCP სამუშაო ამ რეპოდან იწყება.",
+      "starsNumeric": 84000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Context7",
+      "url": "https://github.com/upstash/context7",
+      "stars": "53K",
+      "description": "Context7 არის Upstash-ის MCP სერვერი, რომელიც AI coding agent-ებს ყოველთვის განახლებულ, ვერსია-სპეციფიკურ API დოკუმენტაციას აწვდის. ჩვეულებრივ AI-ს აქვს მოძველებული ან გამოგონილი API-ების რეკომენდაციის პრობლემა — Context7 ავტომატურად ამოწმებს რომელ ვერსიას იყენებ და ზუსტ დოკუმენტაციას ჩასვამს კონტექსტში. TypeScript-ში დაწერილი, context7.com-ზე ხელმისაწვდომი. Claude Code-ს, Cursor-ს, Copilot-ს და ნებისმიერ MCP-თავსებად agent-ს მუშაობს. 53,000+ ვარსკვლავი.",
+      "starsNumeric": 53000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "GitHub MCP",
+      "url": "https://github.com/github/github-mcp-server",
+      "stars": "29K",
+      "description": "GitHub MCP GitHub-ის ოფიციალური MCP სერვერია — AI ასისტენტს GitHub-ის სრული API ხელმისაწვდომი ხდება: issue-ების შექმნა, pull request-ების review, CI/CD-ის მონიტორინგი, repository-ის ძიება და კოდის ანალიზი. Go-ში დაწერილია. ბუნებრივი ენის ბრძანებებით GitHub ოპერაციების ავტომატიზაცია Claude-ს, Copilot-ს, Cursor-ს ან ნებისმიერ MCP client-ს. 29,000+ ვარსკვლავი.",
+      "starsNumeric": 29000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "FastMCP",
+      "url": "https://github.com/jlowin/fastmcp",
+      "stars": "24K",
+      "description": "FastMCP Python-ში MCP სერვერებისა და კლიენტების შექმნის ყველაზე სწრაფი, Pythonic გზაა — „FastAPI for MCP\". decorators-ით minimal code-ით სრულ MCP სერვერს წერ. Jeremiah Lowin-ის (Prefect-ის CEO) მიერ შექმნილი, Anthropic-ის MCP Python SDK-ზე დიდ გავლენას ახდენს. gofastmcp.com, 24,000+ ვარსკვლავი. საკუთარი MCP სერვერის დასაწყებად Python-ში — პირველი არჩევანი.",
+      "starsNumeric": 24000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Serena",
+      "url": "https://github.com/oraios/serena",
+      "stars": "23K",
+      "description": "Serena coding agent-ებისთვის „IDE\"-ს ფუნქციებს MCP-ის სახით გამოფენს. Language Server Protocol-ს (LSP) იყენებს კოდის სემანტიკური გაგებისთვის — symbols, references, definitions პირდაპირ. AI ტექსტუალური grep-ის მაგივრად კოდს ნამდვილად „გებს\". Python-ში, 23,000+ ვარსკვლავი. Claude Code-ში, Cursor-ში ან ნებისმიერ MCP client-ში — Cursor-ის paid-ი ფუნქციების ღია ალტერნატივა.",
+      "starsNumeric": 23000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "n8n-MCP",
+      "url": "https://github.com/czlonkowski/n8n-mcp",
+      "stars": "18K",
+      "description": "n8n-MCP MCP სერვერია, რომელიც AI ასისტენტს n8n ავტომატიზაციის ექსპერტად აქცევს — 1,396 n8n კომპონენტის დოკუმენტაცია, 2,646 კონფიგურაციის მაგალითი და 2,709 workflow template-ი. TypeScript-ში, n8n-mcp.com. Claude Desktop-ში, Claude Code-ში, Cursor-ში, Windsurf-ში. n8n Skills-თან (ამ კოლექციაშია) ერთად — AI n8n-ის ნებისმიერი workflow-ს შენ ნაცვლად ააწყობს. 18,000+ ვარსკვლავი.",
+      "starsNumeric": 18000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Figma Context MCP",
+      "url": "https://github.com/GLips/Figma-Context-MCP",
+      "stars": "14K",
+      "description": "Figma Context MCP AI coding agent-ებს Figma-ს დიზაინ ფაილების ზუსტ მონაცემებს აწვდის — ფერები, ზომები, spacing, component hierarchy — screenshot-ის ნაცვლად სტრუქტურირებული მონაცემებით. TypeScript-ში, Framelink.ai-ის მიერ. Cursor-ში, Claude Code-ში ან სხვა MCP client-ში: Figma-ს დიზაინი → pixel-perfect კოდი პირველივე მცდელობით. 14,000+ ვარსკვლავი.",
+      "starsNumeric": 14000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Code Review Graph",
+      "url": "https://github.com/tirth8205/code-review-graph",
+      "stars": "12K",
+      "description": "Code Review Graph კოდბაზის persistent knowledge graph-ს ქმნის Claude Code-ისთვის — AI მხოლოდ ცვლილებასთან დაკავშირებულ ფაილებს კითხულობს, მთელ repo-ს კი არა. Code review-ზე 6.8-ჯერ ნაკლები ტოკენი, დღიურ coding task-ებზე 49-ჯერამდე — ეს ხარჯებსა და სიჩქარეს მნიშვნელოვნად ცვლის. Python-ში, 22 MCP tool, 19 პროგრამირების ენა. Claude Code-თან, Cursor-თან, Windsurf-თან და Continue-თან.",
+      "starsNumeric": 12000,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Exa MCP",
+      "url": "https://github.com/exa-labs/exa-mcp-server",
+      "stars": "4.3K",
+      "description": "Exa MCP Exa-ს (exa.ai) ოფიციალური MCP სერვერია — AI ასისტენტებს სემანტიკური ვებ ძიებისა და crawling-ის შესაძლებლობა აქვთ. TypeScript-ში დაწერილი. კოდის მაგალითების ძიება, კომპანიების კვლევა, real-time ვებ ინფორმაციის მოძიება — ყველა ერთ ინტერფეისში. Cursor-სა და VS Code-ში ერთი კლიკით ინსტალაცია. Perplexity MCP-ისა და Tavily MCP-ის ალტერნატივა Exa-ს neural search-ის ძლიერებით. 4,000+ ვარსკვლავი.",
+      "starsNumeric": 4300,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Notion MCP",
+      "url": "https://github.com/makenotion/notion-mcp-server",
+      "stars": "4.3K",
+      "description": "Notion MCP Notion-ის ოფიციალური MCP სერვერია — AI ასისტენტს Notion-ის workspace-ზე სრული წვდომა ეძლევა: გვერდების კითხვა, შექმნა, განახლება, ბაზების query. TypeScript-ში, Notion-ის makenotion org-ის მიერ. Cursor-ში, Claude Code-ში ან ნებისმიერ MCP client-ში. Notion-ი project management-ისთვის ან ცოდნის ბაზად რომ იყენებ — AI-ს პირდაპირი წვდომა. 4,000+ ვარსკვლავი.",
+      "starsNumeric": 4300,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Draw.io MCP",
+      "url": "https://github.com/jgraph/drawio-mcp",
+      "stars": "3.2K",
+      "description": "Draw.io MCP draw.io-ს (JGraph Ltd) ოფიციალური MCP სერვერია — AI ასისტენტს diagrams.net-ში ქსელის სქემების, UML-ის, flowchart-ების და სხვა დიაგრამების ავტომატური შექმნის საშუალება ეძლევა. JavaScript-ში. ბუნებრივი ენით სისტემის არქიტექტურა — draw.io ფაილი → browser-ში გახსნა. 4 ინტეგრაციის მეთოდი, 3,000+ ვარსკვლავი.",
+      "starsNumeric": 3200,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Supabase MCP",
+      "url": "https://github.com/supabase-community/supabase-mcp",
+      "stars": "2.6K",
+      "description": "Supabase MCP AI ასისტენტებს Supabase-ის (open-source Firebase ალტერნატივა) მონაცემთა ბაზასთან, Auth-თან და Storage-თან აკავშირებს. TypeScript-ში, supabase.com/mcp. Cursor-ში, Claude Code-ში და Windsurf-ში: ბუნებრივი ენით სთხოვ ცხრილის შექმნას, მონაცემების კითხვას ან schema-ს ცვლილებას — Supabase dashboard-ის გარეშე. 2,600+ ვარსკვლავი.",
+      "starsNumeric": 2600,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Markdownify MCP",
+      "url": "https://github.com/zcaceres/markdownify-mcp",
+      "stars": "2.6K",
+      "description": "Markdownify MCP ნებისმიერი ტიპის ფაილს Markdown-ად გარდაქმნის AI ასისტენტებისთვის — PDF, სურათები, Word, Excel, PowerPoint, YouTube ვიდეო (transcript), ვებ გვერდი, აუდიო. TypeScript-ში. AI-ს \"კვება\" ნებისმიერი ფორმატიდან — ერთი სერვერი ყველა კონვერსიისთვის. RAG pipeline-ებისა და document analysis workflow-ებისთვის. 2,600+ ვარსკვლავი.",
+      "starsNumeric": 2600,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Perplexity MCP",
+      "url": "https://github.com/perplexityai/modelcontextprotocol",
+      "stars": "2.1K",
+      "description": "Perplexity MCP Perplexity AI-ის ოფიციალური MCP სერვერია — AI ასისტენტებს real-time ვებ ძიების, ღრმა კვლევისა და მსჯელობის შესაძლებლობა ეძლევა. TypeScript/Node-ში. **3 ინსტრუმენტი**: `sonar-pro` (ზოგადი search+chat), `sonar-deep-research` (კომპრეჰენსიული კვლევა), `sonar-reasoning-pro` (რთული ანალიზი). Cursor, VS Code, Kiro-ში ერთი კლიკით ინსტალაცია. Perplexity-ის citations-ზე დაფუძნებული პასუხები ჰალუცინაციებს ამცირებს. 2,000+ ვარსკვლავი.",
+      "starsNumeric": 2100,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Claude Peers MCP",
+      "url": "https://github.com/louislva/claude-peers-mcp",
+      "stars": "1.9K",
+      "description": "Claude Peers MCP ლოკალური MCP სერვერია, რომელიც სხვადასხვა Claude Code სესიებს ერთმანეთს ამოაჩენინებს და real-time შეტყობინებების გაცვლის საშუალებას აძლევს. TypeScript-ში. თუ პარალელურად რამდენიმე პროექტზე მუშაობ სხვადასხვა Claude Code ინსტანციებით, ისინი ერთმანეთს კოორდინაციას გაუწევენ. ტექნიკურად MCP სერვერია — Plugins სექციაში მოხვდა, მაგრამ MCP ინტეგრაციებს მიეკუთვნება.",
+      "starsNumeric": 1900,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Tavily MCP",
+      "url": "https://github.com/tavily-ai/tavily-mcp",
+      "stars": "1.8K",
+      "description": "Tavily MCP production-ready MCP სერვერია real-time ვებ ძიებისთვის, კონტენტის extraction-ისთვის, sitemap-ისა და crawling-ისთვის — ყველა ოპერაცია ერთ სერვერში. JavaScript-ში. ჰოსტირებული ვერსიაც ხელმისაწვდომია (mcp.tavily.com) ლოკალური ინსტალაციის გარეშე. AI research agent-ებისა და automated web monitoring-ისთვის. 1,800+ ვარსკვლავი.",
+      "starsNumeric": 1800,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "LinkedIn MCP",
+      "url": "https://github.com/stickerdaniel/linkedin-mcp-server",
+      "stars": "1.7K",
+      "description": "LinkedIn MCP LinkedIn-ის ღია კოდის MCP სერვერია — Claude-ს ან ნებისმიერ MCP-თავსებად AI ასისტენტს LinkedIn-ის profiles, companies, jobs და messages-ზე წვდომა ეძლევა. Python-ში. სამუშაოს მძებნელებისთვის (ვაკანსიების ავტო-ანალიზი), recruiters-ისთვის (კანდიდატების კვლევა) ან sales teams-ისთვის (prospect-ების ძიება). 1,600+ ვარსკვლავი — LinkedIn API-ის official SDK-ი არ არის, unofficial integration.",
+      "starsNumeric": 1700,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Stripe MCP",
+      "url": "https://github.com/stripe/agent-toolkit",
+      "stars": "1.5K",
+      "description": "Stripe Agent Toolkit Stripe-ის ოფიციალური toolkit-ია AI-powered financial products-ის ასაშენებლად — MCP სერვერი, LangChain integration, CrewAI integration და Vercel AI SDK მხარდაჭერა ერთ პაკეტში. TypeScript-ში, docs.stripe.com/agents. AI ასისტენტს შეუძლია მომხმარებლების ძიება, payments-ის შექმნა, subscriptions-ის მართვა. Stripe-ის ოფიციალური, 1,500 ვარსკვლავი — MCP-ზე ფოკუსირებული toolkit-ი.",
+      "starsNumeric": 1500,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Apify MCP",
+      "url": "https://github.com/apify/apify-mcp-server",
+      "stars": "1.1K",
+      "description": "Apify MCP Apify-ის ოფიციალური MCP სერვერია — AI ასისტენტებს Apify Store-ის 1,000+ მზა web scraper-ი და automation tool ხელმისაწვდომი ხდება. Instagram, TikTok, Amazon, Google Maps, LinkedIn — ნებისმიერი ვებსაიტიდან სტრუქტურირებული მონაცემები. TypeScript-ში, mcp.apify.com. სოციალური მედიის monitoring-ისთვის, market research-ისთვის ან lead generation-ისთვის — 1,100+ ვარსკვლავი.",
+      "starsNumeric": 1100,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Power BI Modeling MCP",
+      "url": "https://github.com/microsoft/powerbi-modeling-mcp",
+      "stars": "677",
+      "description": "Power BI Modeling MCP Microsoft-ის ოფიციალური MCP სერვერია Power BI-ის სემანტიკური მოდელირებისთვის. AI ასისტენტს შეუძლია DAX შეკითხვების გაშვება, data models-ის შექმნა და რედაქტირება, row-level security და მრავალენოვანი თარგმანი — ბუნებრივი ენით. Power BI Desktop-თან, Fabric workspace-თან და Power BI Project ფაილებთან. Microsoft-ის ოფიციალური გამოშვება, 677 ვარსკვლავი — ჯერ ახალი, მაგრამ enterprise BI-სთვის მნიშვნელოვანი.",
+      "starsNumeric": 677,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Sentry MCP",
+      "url": "https://github.com/getsentry/sentry-mcp",
+      "stars": "666",
+      "description": "Sentry MCP Sentry-ის ოფიციალური MCP სერვერია error tracking-ის AI-თ ინტეგრაციისთვის. AI ასისტენტს Sentry-ის error reports-ზე, stack trace-ებზე, issue frequency-ის ტრენდებსა და performance data-ზე წვდომა ეძლევა. TypeScript-ში, mcp.sentry.dev. 666 ვარსკვლავი — production bug-ების AI-ასისტირებული დიაგნოსტიკისთვის. (შენიშვნა: README-ში მითითებული 1.8K ვარსკვლავი მნიშვნელოვნად გადაჭარბებულია.)",
+      "starsNumeric": 666,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "E2B MCP",
+      "url": "https://github.com/e2b-dev/mcp-server",
+      "stars": "393",
+      "description": "E2B MCP E2B-ის MCP სერვერი იყო AI agent-ებისთვის cloud sandbox-ში კოდის გასაშვებად — Python, JavaScript, Bash იზოლირებულ გარემოში. JavaScript-ში. **ყურადღება: ეს repo archived (მიტოვებული) სტატუსშია 2026 წლიდან** — აქტიური მხარდაჭერა არ არის. E2B-ის ახალი MCP ინტეგრაციისთვის e2b.dev-ის ოფიციალური დოკუმენტაცია შეამოწმე. 393 ვარსკვლავი.",
+      "starsNumeric": 393,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Metricool MCP",
+      "url": "https://github.com/metricool/mcp-metricool",
+      "stars": "36",
+      "description": "Metricool MCP Metricool-ის ოფიციალური MCP სერვერია სოციალური მედიის მართვისთვის. AI ასისტენტს შეუძლია Instagram-ის, Facebook-ის, Twitter/X-ის, TikTok-ისა და LinkedIn-ის analytics-ის ანალიზი და post-ების დაგეგმვა. Python-ში. 36 ვარსკვლავი — ახალი, მაგრამ Metricool-ის მომხმარებლებისთვის AI-ს სოციალური მედიის მართვის ავტომატიზაციისთვის.",
+      "starsNumeric": 36,
+      "categorySlug": "mcp",
+      "categoryEmoji": "🔌",
+      "categoryGeorgian": "MCP ინტეგრაციები"
+    },
+    {
+      "name": "Firecrawl",
+      "url": "https://github.com/mendableai/firecrawl",
+      "stars": "111K",
+      "description": "Firecrawl არის Mendable AI-ის (YC S23) ვებ-სკრეიპინგის API, რომელიც ნებისმიერ URL-ს AI-სთვის ოპტიმიზებულ Markdown-ად ან JSON-ად გარდაქმნის. ის წყვეტს LLM-ების ერთ-ერთ მთავარ პრობლემას — ვებ გვერდების „ჭუჭყიანი\" HTML-ის სუფთა, სტრუქტურირებულ ფორმატად გადაყვანას. scrape, crawl, search და extract ოპერაციები ერთ API-ში ერთიანდება; JavaScript-ის რენდერი და anti-bot დაცვის გვერდის ავლა ჩაშენებულია. Python და TypeScript SDK-ები გამოყოფილია, self-hosted ან cloud deployment-ი შესაძლებელია. 111K+ ვარსკვლავით ეს კატეგორიის ყველაზე პოპულარული ინსტრუმენტია AI pipeline-ებისთვის ვებ-მონაცემების მიწოდებაში.",
+      "starsNumeric": 111000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Browser Use",
+      "url": "https://github.com/browser-use/browser-use",
+      "stars": "89K",
+      "description": "Browser Use არის Python-ის ბიბლიოთეკა, რომელიც AI აგენტს ნამდვილი ბრაუზერის გამოსაყენებლად აძლევს შესაძლებლობას — ვებსაიტებზე ნავიგაცია, ფორმების შევსება, ღილაკებზე დაჭერა და ინფორმაციის ამოღება ისევე, როგორც ადამიანი. ის წყვეტს იმ პრობლემას, რომ LLM-ები ტექსტობრივი ინტერფეისებისთვის იყო განკუთვნილი, ხოლო ვების უმეტესი ნაწილი ვიზუალურია. Playwright-ზეა დაშენებული, multi-tab მხარდაჭერით, DOM-ის სტრუქტურის ავტომატური ანალიზით და OpenAI, Anthropic, Gemini მოდელებთან ინტეგრაციით. 89K+ ვარსკვლავი და სწრაფად მზარდი ეკოსისტემა მას browser automation-ის defacto სტანდარტად აქცევს AI-native პროექტებში.",
+      "starsNumeric": 89000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Crawl4AI",
+      "url": "https://github.com/unclecode/crawl4ai",
+      "stars": "64K",
+      "description": "Crawl4AI არის ღია კოდის Python web crawler, რომელიც სპეციალურად LLM-ებისა და RAG pipeline-ებისთვის არის ოპტიმიზებული. მისი მთავარი ღირსება ის არის, რომ Firecrawl-ისგან განსხვავებით, სრულად უფასოა, ლოკალურად გაშვებადია და API-ის ლიმიტები არ გააჩნია. JavaScript-ის რენდერი, semantic chunking, structured data extraction (CSS/XPath/LLM-ზე დაფუძნებული) და async crawling ჩაშენებულია. Scrapy-ზე 6-ჯერ სწრაფია benchmark-ების მიხედვით; Python AsyncIO-ზე დაშენებული. ქართული RAG სისტემებისთვის, სადაც ვებ-მონაცემების ლოკალური შეგროვება გჭირდება, ეს ყველაზე ეფექტური არჩევანია.",
+      "starsNumeric": 64000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Playwright MCP",
+      "url": "https://github.com/microsoft/playwright-mcp",
+      "stars": "31K",
+      "description": "Playwright MCP არის Microsoft-ის ოფიციალური MCP სერვერი, რომელიც Claude-ს, Cursor-ს და სხვა AI ასისტენტებს ვებ ბრაუზერის სრული კონტროლის საშუალებას აძლევს. AI ბრაუზერის accessibility tree-ს წაიკითხავს — ვიზუალური ელემენტების სტრუქტურას — სკრინშოტების გარეშე, რაც მუშაობას ბევრად ზუსტსა და სწრაფს ხდის. navigation, click, fill, screenshot, PDF export — ყველა ოპერაცია MCP პროტოკოლით ხდება ხელმისაწვდომი. TypeScript-ში დაწერილია, npm-ზე გამოქვეყნებული.",
+      "starsNumeric": 31000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Agent Browser",
+      "url": "https://github.com/vercel-labs/agent-browser",
+      "stars": "30K",
+      "description": "Agent Browser არის Vercel Labs-ის (Next.js-ის შემქმნელი) CLI ინსტრუმენტი, რომელიც AI აგენტებისთვის ბრაუზერის ავტომატიზაციას ახორციელებს. Rust-ში დაწერილია, რაც მას სიმდიდრული სიჩქარისა და დაბალი მეხსიერების მოხმარების კომბინაციას აძლევს. ინსტრუმენტი command-line ინტერფეისს გვთავაზობს AI სამუშაო ნაკადებთან ინტეგრაციისთვის, ვიდრე ვიზუალური API-სა. Vercel ეკოსისტემის ნაწილი, 2026 წლის იანვარში გამოშვებული.",
+      "starsNumeric": 30000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Lightpanda",
+      "url": "https://github.com/lightpanda-io/browser",
+      "stars": "29K",
+      "description": "Lightpanda არის headless ბრაუზერი, რომელიც ნულიდან Zig-ში დაიწერა სპეციალურად AI სამუშაო ნაკადებისა და automation-ისთვის. Chrome-თან შედარებით 11-ჯერ სწრაფია და 9-ჯერ ნაკლებ RAM-ს მოიხმარს, რაც მას სერვერულ გარემოში მასშტაბირებისთვის ეკონომიურ ალტერნატივად აქცევს. Puppeteer-ისა და Playwright-ის სკრიპტებთან თავსებადია, ანუ migration ნაკლები ძალისხმევით ხდება. Zig-ის low-level კონტროლი სრულ JavaScript-ის ინტერპრეტაციასთან ერთად გამოყენებულია web scraping-ის ინსტრუმენტებით დატვირთულ სერვერებზე.",
+      "starsNumeric": 29000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Stagehand",
+      "url": "https://github.com/browserbase/stagehand",
+      "stars": "22K",
+      "description": "Stagehand არის Browserbase-ის (YC W24) TypeScript SDK, რომელიც Playwright-ს AI-ს ბუნებრივ ენასთან ათავსებს. ნაცვლად ფიქსირებული სელექტორებისა, შეგიძლია ბრძანებები ბუნებრივ ენაზე მისცე: `page.act(\"click the login button\")` ან `page.extract(\"get the product price\")`. ეს hybrid მიდგომა — კოდი + ბუნებრივი ენა — Playwright-ის სუფთა ავტომატიზაციაზე უფრო სტაბილურია, რადგან LLM ადაპტირდება ვებ გვერდის სტრუქტურის ცვლილებებზე. TypeScript-ში დაწერილია, Python SDK-იც ხელმისაწვდომია.",
+      "starsNumeric": 22000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Agent-Reach",
+      "url": "https://github.com/Panniantong/Agent-Reach",
+      "stars": "18K",
+      "description": "Agent-Reach არის Python CLI ინსტრუმენტი, რომელიც AI აგენტს 10+ სოციალური და საინფორმაციო პლატფორმის წაკითხვის უნარს აძლევს ერთი ინტერფეისით. Twitter/X, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu და სხვა — ყველა ერთი სტანდარტული API-ით, ოფიციალური API გასაღებების გარეშე (zero API fees). Python-ში დაწერილი, 2026 წლის თებერვლიდან 18K ვარსკვლავი დააგროვა — ეს ტემპი სისწრაფეზე მეტყველებს. AI კვლევის, მონიტორინგის და მონაცემთა შეგროვების სამუშაო ნაკადებისთვის გამოსაყენებელია.",
+      "starsNumeric": 18000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "opencli",
+      "url": "https://github.com/jackwener/opencli",
+      "stars": "17K",
+      "description": "opencli არის JavaScript-ის universal CLI runtime, რომელიც ნებისმიერ ვებსაიტს, Electron-ის აპლიკაციას ან ადგილობრივ პროგრამას სტანდარტული ტერმინალის ბრძანებად გარდაქმნის. AI-native ინტეგრაციისთვის AGENT.md ფორმატს იყენებს, რომელიც AI-ს აძლევს კონტექსტს ხელსაწყოს გამოყენების შესახებ. 70+ ინსტრუმენტი უკვე მხარდაჭერილია, ახალი ხელსაწყოების დამატება კი გარე API-ის გარეშეა შესაძლებელი. 2026 წლის მარტში გამოშვებული, სწრაფად იკრებს პოპულარობას AI CLI ეკოსისტემაში.",
+      "starsNumeric": 17000,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Playwright CLI",
+      "url": "https://github.com/microsoft/playwright-cli",
+      "stars": "9.2K",
+      "description": "Playwright CLI არის Microsoft-ის TypeScript ინსტრუმენტი Playwright-ის ბრაუზერის ტესტებისა და სკრიპტების სამართავად ტერმინალიდან. ის ბრაუზერში ნებისმიერ მოქმედებას ჩაწერს და ავტომატურად გენერირებს Playwright კოდს — JavaScript, TypeScript, Python ან C#-ში. სელექტორების ინსპექტირება, სკრინშოტები და tracing-ი ჩაშენებულია. MCP სერვერის ოვერჰედის გარეშე მუშაობს, სადაც მხოლოდ ბრძანების ხაზი კმარა.",
+      "starsNumeric": 9200,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Firecrawl MCP Server",
+      "url": "https://github.com/firecrawl/firecrawl-mcp-server",
+      "stars": "6.1K",
+      "description": "Firecrawl MCP Server არის Firecrawl-ის ოფიციალური MCP ინტეგრაცია, რომელიც Claude Desktop-ს, Cursor-ს და სხვა MCP-თავსებად AI ასისტენტებს ვებ-სკრეიპინგის სრული შესაძლებლობებს უმატებს. scrape, crawl, search, deep research — 12+ ინსტრუმენტი ერთ სერვერშია, ავტომატური retry-ით და rate limiting-ით. JavaScript-ში დაწერილი, Firecrawl API-ის გასაღები საჭიროა. Cursor ან Claude-ში ინსტალაციის შემდეგ AI-ს ნებისმიერი ვებ გვერდის სკრეიპინგი შეუძლია პირდაპირ კონვერსაციიდან.",
+      "starsNumeric": 6100,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Browser Harness",
+      "url": "https://github.com/browser-use/browser-harness",
+      "stars": "5.9K",
+      "description": "Browser Harness არის Browser Use გუნდის Python ფრეიმვორკი, რომელიც LLM-ებს ბრაუზერში ნებისმიერი ამოცანის შესრულების საშუალებას აძლევს self-healing მექანიზმით. „Self-healing\" ნიშნავს, რომ ვებ გვერდის სტრუქტურა ან CSS სელექტორი რომ შეიცვალოს, სისტემა ავტომატურად ადაპტირდება და სამუშაო ნაკადი არ ირღვევა. 2026 წლის აპრილში გამოშვებული, სწრაფად ვითარდება Browser Use-ის ეკოსისტემის ფარგლებში. Python-ში დაწერილი, LLM-ების ბრაუზერ-ავტომატიზაციის სიმტკიცეს ამაღლებს.",
+      "starsNumeric": 5900,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Cloudflare MCP",
+      "url": "https://github.com/cloudflare/mcp-server-cloudflare",
+      "stars": "3.7K",
+      "description": "mcp-server-cloudflare არის Cloudflare-ის ოფიციალური MCP სერვერების კოლექცია, რომელიც AI ასისტენტებს Cloudflare-ის პლატფორმის სრული მართვის საშუალებას აძლევს. Workers, KV, R2, D1, Browser Rendering, DNS ანალიტიკა და სხვა სერვისები — 13+ MCP სერვერი ერთ რეპოზიტორიაში. TypeScript-ში დაწერილი. Cloudflare-ის ინფრასტრუქტურის მართვა Claude-ს ან Cursor-ს შეუძლია პირდაპირ კონვერსაციიდან, CLI-ის გარეშე.",
+      "starsNumeric": 3700,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "Bright Data MCP",
+      "url": "https://github.com/brightdata/brightdata-mcp",
+      "stars": "2.3K",
+      "description": "Bright Data MCP არის Bright Data-ს ოფიციალური MCP სერვერი, რომელიც AI ასისტენტებს ვებ-სკრეიპინგს anti-bot დაცვის გვერდის ავლით ახდენს. Bright Data-ს კომერციული proxy ქსელი — მილიონობით IP-ით — ამ სერვერის ბექ-ენდია, რაც ბლოკირებული ვებ გვერდების წვდომას შესაძლებელს ხდის. JavaScript-ში დაწერილია, Bright Data-ს API-ის გასაღები სჭირდება (ფასიანი სერვისი). ორგანიზაციებისთვის, სადაც ვებ მონაცემები კომერციული მნიშვნელობისაა და სტანდარტული scraper-ები ბლოკდება, ეს პრემიუმ გამოსავალია.",
+      "starsNumeric": 2300,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "rdrr",
+      "url": "https://github.com/fkonovalov/rdrr",
+      "stars": "138",
+      "description": "rdrr არის TypeScript-ის CLI ინსტრუმენტი, რომელიც ნებისმიერ URL-ს AI-სთვის სუფთა Markdown-ად გარდაქმნის headless ბრაუზერის გარეშე. ვებ გვერდები, YouTube ვიდეოები, GitHub issues/PR-ები, PDF-ები და X/Twitter პოსტები — ყველა ერთი ბრძანებით. 20+ საიტ-სპეციფიკური extractor ჩაშენებულია, რაც HTML-ის ჩვეულებრივ parsing-ზე ბევრად სუფთა შედეგს იძლევა. CLI-ისა და ბიბლიოთეკის სახით გამოიყენება. 2026 წლის მარტში გამოშვებული ახალი პროექტია; ამჟამად 138 ვარსკვლავი.",
+      "starsNumeric": 138,
+      "categorySlug": "scraping",
+      "categoryEmoji": "🕷️",
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+    },
+    {
+      "name": "LangChain",
+      "url": "https://github.com/langchain-ai/langchain",
+      "stars": "134K",
+      "description": "LangChain არის Python-ისა და JavaScript-ის ფრეიმვორკი LLM-ზე დაფუძნებული აპლიკაციებისა და AI აგენტების ასაშენებლად, Harrison Chase-მა 2022 წლის ოქტომბერში შექმნა. ის 700+ ინტეგრაციას, chains, agents, memory, document loaders და tools-ის პრიმიტივებს გვთავაზობს ერთ ეკოსისტემაში. LangGraph (გრაფ-დაფუძნებული ორკესტრაცია) და LangSmith (მონიტორინგი) LangChain-ის ეკოსისტემის ნაწილია. 134K ვარსკვლავით ყველაზე ფართოდ გავრცელებული AI ფრეიმვორკია; ბევრი სხვა ფრეიმვორკი მის კონვენციებს მიჰყვება, თუმცა LangChain-ზე პირდაპირ არ არის დამოკიდებული.",
+      "starsNumeric": 134000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Hermes-agent",
+      "url": "https://github.com/nousresearch/hermes-agent",
+      "stars": "113K",
+      "description": "Hermes Agent არის Nous Research-ის Python AI აგენტი, რომელიც გამოცდილებიდან სწავლობს და სესიებს შორის მეხსიერებას ინახავს — „იზრდება\" მომხმარებელთან ერთად. Telegram-ში, Discord-ში, Slack-ში, WhatsApp-ში და ავტომატურ განრიგზე მუშაობს. 113K+ ვარსკვლავით ამ კოლექციის ერთ-ერთი ყველაზე სწრაფად მზარდი პროექტია. Nous Research ცნობილია მაღალხარისხიანი ღია LLM მოდელებით (Hermes სერია); ეს აგენტი იმავე ფილოსოფიას ახორციელებს — ძლიერი, ღია, სასაქონლო.",
+      "starsNumeric": 113000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "MetaGPT",
+      "url": "https://github.com/geekan/MetaGPT",
+      "stars": "67K",
+      "description": "MetaGPT არის Python-ის მრავალაგენტური ფრეიმვორკი, სადაც AI აგენტები Product Manager, Architect, Engineer და QA ინჟინრის როლებს ითამაშებენ პროგრამული პროდუქტის ერთობლივად შესაქმნელად. ერთი ბუნებრივი ენის მოთხოვნიდან — PRD-მდე, design doc-მდე, კოდამდე და ტესტებამდე — სრული pipeline-ი ავტომატურად გადის. ჩინური DeepWisdom კომპანიის შექმნილია, 2023 წელს გამოვიდა და სწრაფად 67K ვარსკვლავი დააგროვა. CrewAI-ისა და AutoGen-ის ალტერნატიულ მიდგომას წარმოადგენს — role-playing paradigm-ის საფუძველია.",
+      "starsNumeric": 67000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "AutoGen",
+      "url": "https://github.com/microsoft/autogen",
+      "stars": "57K",
+      "description": "AutoGen არის Microsoft Research-ის Python ფრეიმვორკი, სადაც რამდენიმე AI აგენტი ერთმანეთთან ესაუბრება და კომპლექსურ პრობლემებს ერთობლივად წყვეტს. conversation pattern-ები, tool use, human-in-the-loop, code execution — ყველა abstractions-ი ჩაშენებულია. 2026 წლის აპრილში Semantic Kernel-თან ერთად Microsoft Agent Framework 1.0-ის ოფიციალურ ნაწილად გამოცხადდა. Python-ში, MIT ლიცენზიით. Microsoft Azure-სთან ღრმა ინტეგრაცია, enterprise AI deployments-ისთვის გამოიყენება.",
+      "starsNumeric": 57000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "AI Hedge Fund",
+      "url": "https://github.com/virattt/ai-hedge-fund",
+      "stars": "57K",
+      "description": "AI Hedge Fund არის Python-ის სიმულაციური პროექტი, სადაც AI აგენტები Warren Buffett-ის, Charlie Munger-ისა და Michael Burry-ს ინვესტიციური სტილების მიბაძვით ერთობლივად აანალიზებენ საფონდო ბირჟის მონაცემებს. LangGraph-ის multi-agent ორქესტრაციაზეა დაშენებული — სხვადასხვა „ანალიტიკოსი\" (fundamental, technical, sentiment, risk) პარალელურად ამუშავებს მონაცემებს და შედეგებს აერთებს. ეს არ არის რეალური სავაჭრო სისტემა — გამოყენება მხოლოდ საგანმანათლებლო მიზნებისთვისაა. LangGraph-ის production-ready გამოყენების ერთ-ერთი საუკეთესო real-world მაგალითია.",
+      "starsNumeric": 57000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "CrewAI",
+      "url": "https://github.com/crewaiinc/crewai",
+      "stars": "49K",
+      "description": "CrewAI არის Python-ის ფრეიმვორკი, სადაც AI აგენტებს ოსხვა „თანამდებობები\" ენიჭებათ (მკვლევარი, მწერალი, შემმოწმებელი) და ისინი ერთი გუნდივით ერთობლივად ასრულებენ ამოცანებს. role-playing პარადიგმა სხვა ფრეიმვორკებისგან განარჩევს — აგენტები backstory-ით, goal-ებითა და კონკრეტული tools-ით კონფიგურირდება. Python-ში, 100,000+ დეველოპერი იყენებს production-ში, დღეში 12+ მილიონი ამოცანა სრულდება CrewAI-ზე. ყველაზე ადვილი გზა multi-agent სამუშაო ნაკადის სწრაფად ასაწყობად.",
+      "starsNumeric": 49000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "nanobot",
+      "url": "https://github.com/HKUDS/nanobot",
+      "stars": "40K",
+      "description": "nanobot არის HKUDS-ის (ჰონგ კონგის მეცნიერებისა და ტექნოლოგიის უნივერსიტეტი) ულტრა-მსუბუქი Python AI აგენტი, რომლის სრული კოდბაზა 4,000 ხაზს არ აღემატება. კომპლექსური ფრეიმვორკებისგან განსხვავებით, nanobot-ის ბირთვი transparent-ია — ადვილია გაგება, მოდიფიცირება და deploy-ი. Telegram, Discord, Slack, WhatsApp და 5+ სხვა პლატფორმაზე მუშაობს პირველადი კონფიგურაციით. HKUDS OpenSpace ეკოსისტემის ნაწილია. 40K ვარსკვლავი სწრაფად მოაგროვა სიმარტივისა და ეფექტურობის კომბინაციის გამო.",
+      "starsNumeric": 40000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "agno",
+      "url": "https://github.com/agno-agi/agno",
+      "stars": "39K",
+      "description": "agno (ყოფილი phidata) არის Python-ის lightweight production framework AI აგენტებისთვის, რომელიც 2025 წელს rebrand-ი გაიარა. agents, multi-agent teams, workflows, memory, tools, knowledge bases და monitoring ერთ მინიმალური dependencies-ის პაკეტში ერთიანდება. სხვა ფრეიმვორკებისგან განსხვავებით, agno-ს ბირთვი მარტივი და გასაგებია — production deployment-ისთვის ზედმეტი abstractions-ი არ დაგჭირდება. 39K ვარსკვლავი; მცირე გუნდებისთვის, ვინც LangChain-ის სირთულის გარეშე production-ready აგენტებს ქმნის, ეს ეფექტური ჩარჩოა.",
+      "starsNumeric": 39000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "DSPy",
+      "url": "https://github.com/stanfordnlp/dspy",
+      "stars": "34K",
+      "description": "DSPy არის Stanford NLP-ის Python ფრეიმვორკი, რომელიც LLM-ებთან მუშაობის პარადიგმას ცვლის: prompt-ის ხელით წერის ნაცვლად პროგრამულ სტრუქტურებს (signatures, modules, optimizers) სწერ. DSPy ავტომატურად ოპტიმიზებს prompt-ებსა და few-shot examples-ს მოცემული მეტრიკის მიხედვით — ანუ კომპილატორი prompt-ებისთვის. Omar Khattab-ის ხელმძღვანელობით შეიქმნა, NeurIPS-ისა და EMNLP-ის ნაშრომებით მხარდაჭერილია. ვინც LLM pipeline-ებს წერს და prompt engineering-ის ხელნაწერ სამუშაოს მცირე კოდით ჩაანაცვლებს, ეს ფრეიმვორკი მთავარი ინსტრუმენტია.",
+      "starsNumeric": 34000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "LangGraph",
+      "url": "https://github.com/langchain-ai/langgraph",
+      "stars": "30K",
+      "description": "LangGraph არის LangChain AI-ის Python ფრეიმვორკი, სადაც AI აგენტების ლოგიკა მიმართული გრაფის სახით (nodes + edges) იგება. ეს საშუალებას იძლევა რთული სცენარები — ციკლები, ტოტები, შუალედური მდგომარეობის შენახვა — LangChain-ის ხაზოვანი chains-ის მიღმა. built-in checkpointing, human-in-the-loop და streaming ჩაშენებულია. Uber, LinkedIn, Klarna production-ში იყენებს. long-running, stateful AI სამუშაო ნაკადებისთვის — customer support, code review, research — LangGraph production-ის სტანდარტი გახდა.",
+      "starsNumeric": 30000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Semantic Kernel",
+      "url": "https://github.com/microsoft/semantic-kernel",
+      "stars": "27K",
+      "description": "Semantic Kernel არის Microsoft-ის SDK AI-ის enterprise აპლიკაციებში ინტეგრაციისთვის, C#, Python და Java-ში. plugin-based არქიტექტურა AI ფუნქციების ჯაჭვური გამოძახების საშუალებას იძლევა; Azure OpenAI, Azure AI Foundry და Microsoft Copilot-თან ღრმა ინტეგრაცია აქვს. AutoGen-თან ერთად Microsoft Agent Framework 1.0-ის ნაწილია (2026 აპრილი). Microsoft-ის ეკოსისტემაში (.NET, Azure, Office 365) მომუშავე enterprise გუნდებისთვის AI ინტეგრაციის ყველაზე ბუნებრივი გზაა.",
+      "starsNumeric": 27000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "smolagents",
+      "url": "https://github.com/huggingface/smolagents",
+      "stars": "26K",
+      "description": "smolagents არის Hugging Face-ის მინიმალისტური Python ბიბლიოთეკა AI აგენტებისთვის, რომელიც „code-first\" მიდგომას ეფუძნება — აგენტები JSON-ის ნაცვლად Python კოდს წერენ მოქმედებების შესასრულებლად. ბიბლიოთეკის სრული ბირთვი 2,000 ხაზ კოდამდეა, რაც განსაკუთრებით გასაგებსა და გასახვეწ ხდის. 100+ LLM მოდელი მხარდაჭერილია — Hugging Face-ის, OpenAI-ის, Anthropic-ის, Ollama-სა და სხვა. ToolCallingAgent (JSON tool calls) და CodeAgent (Python კოდი) ორი მთავარი ინტერფეისია. ვინც მარტივი, transparent agent logic-ი სურს, smolagents ოპტიმალური საწყისი წერტილია.",
+      "starsNumeric": 26000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "OpenAI Agents SDK",
+      "url": "https://github.com/openai/openai-agents-python",
+      "stars": "24K",
+      "description": "OpenAI Agents SDK არის OpenAI-ის ოფიციალური Python ფრეიმვორკი multi-agent სამუშაო ნაკადებისთვის. agents, handoffs, guardrails, tracing, human-in-the-loop, ხმოვანი აგენტები — ყველა abstractions ჩაშენებულია მინიმალური კოდის ზრდით. Swarm-ის (OpenAI-ს ადრინდელი სასწავლო ფრეიმვორკი) production-ready მემკვიდრეა. 100+ LLM მხარდაჭერილია, არა მხოლოდ OpenAI-ს მოდელები. 2025 წლის მარტიდან v0.14-მდე სწრაფი განვითარება; CrewAI-ისა და AutoGen-ის პირდაპირი კონკურენტი OpenAI-ისგანვე.",
+      "starsNumeric": 24000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Vercel AI SDK",
+      "url": "https://github.com/vercel/ai",
+      "stars": "23K",
+      "description": "Vercel AI SDK არის Vercel-ის (Next.js-ის შემქმნელი) TypeScript toolkit, რომელიც full-stack AI აპლიკაციების სწრაფ აშენებას ახდენს შესაძლებლად. streaming responses, tool calling, structured outputs, multi-step agents — ყველა abstractions ჩაშენებულია React/Next.js-ისთვის ოპტიმიზებულად. OpenAI, Anthropic, Google, Mistral, Ollama და სხვა provider-ები ერთი unified API-ით ხდება ხელმისაწვდომი. თვეში 20+ მილიონი ჩამოტვირთვა npm-ზე. Next.js-ისა და React-ის გამოყენებით AI ვებ აპლიკაციების ასაშენებლად defacto სტანდარტია.",
+      "starsNumeric": 23000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Mastra",
+      "url": "https://github.com/mastra-ai/mastra",
+      "stars": "23K",
+      "description": "Mastra არის TypeScript-ის AI ფრეიმვორკი Gatsby-ის გუნდისგან, YC W25-ის batch-ში შეიქმნა და $13M დაფინანსება მიიღო. agents, workflows, RAG, evaluations და integrations ერთ toolkit-ში ერთიანდება. TypeScript-ში — Vercel AI SDK-ის Zod-based typing-ის ფილოსოფიის მიმდევარი. სხვა JS/TS ფრეიმვორკებისგან განარჩევს built-in evaluation suite (agent-ების ხარისხის გაზომვა) და workflow engine. Node.js/TypeScript სტეკის მქონე გუნდებისთვის, ვინც AI production-ში ქონს, კარგი ალტერნატივაა.",
+      "starsNumeric": 23000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Swarm",
+      "url": "https://github.com/openai/swarm",
+      "stars": "21K",
+      "description": "Swarm არის OpenAI Solution Team-ის სასწავლო Python ფრეიმვორკი, რომელიც მრავალაგენტური ორკესტრაციის ძირითად ცნებებს — agents და handoffs — მინიმალური კოდით ასახავს. ის production-ისთვის განკუთვნილი არ არის (GitHub-ზე official status-ი ამ მიმართულებით ნათლად მიუთითებს), არამედ სასწავლო რესურსია OpenAI Agents SDK-ის (openai-agents-python) კონცეფციების გასაგებად. Swarm-ის სიმარტივის ფილოსოფია საფუძვლად დაედო OpenAI-ის ახალ ოფიციალურ Agents SDK-ს. ვისაც multi-agent სისტემების ლოგიკა სურს სწრაფად გაიგოს — ეს ყველაზე მოკლე სასწავლო გზაა.",
+      "starsNumeric": 21000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Archon",
+      "url": "https://github.com/coleam00/Archon",
+      "stars": "19K",
+      "description": "Archon არის TypeScript-ის open-source ინსტრუმენტი, რომელიც AI კოდირების სამუშაო ნაკადებს deterministic-ად და გამეორებადად ხდის — YAML-ის harness განმარტებებით. იდეა მარტივია: AI-ს კოდირებაში კი, მაგრამ ფიქსირებულ ფაზებს (planning, implementation, validation, review) მიჰყვება, სადაც ყოველი ნაბიჯი audit-ირებადი და rollback-ებადია. CI/CD pipeline-ებთან ინტეგრაციისთვის — სადაც AI-ს კოდი production-ში შეჰყავს — განსაკუთრებით ეფექტურია. „Dockerfile AI-ისთვის\" კონცეფციის პრაქტიკული განხორციელება.",
+      "starsNumeric": 19000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "Pydantic AI",
+      "url": "https://github.com/pydantic/pydantic-ai",
+      "stars": "16K",
+      "description": "Pydantic AI არის Pydantic-ის გუნდის Python ფრეიმვორკი AI აგენტებისთვის, რომელიც type safety-სა და validation-ს სტრუქტურის ცენტრში ათავსებს. Pydantic-ის ბევრი მოდელი (OpenAI SDK, Anthropic SDK, LangChain) უკვე Pydantic-ზეა დაშენებული — Pydantic AI ამ ეკოსისტემის ბუნებრივი გაგრძელებაა. dependency injection, structured outputs, multi-turn conversations, built-in monitoring (Pydantic Logfire) ჩაშენებულია. Python-ის type system-ის სრული გამოყენება agent-ების ვალიდაციასა და debugging-ს ბევრად ამარტივებს.",
+      "starsNumeric": 16000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "OpenSandbox",
+      "url": "https://github.com/alibaba/OpenSandbox",
+      "stars": "10K",
+      "description": "OpenSandbox არის Alibaba-ს Python sandbox runtime, რომელიც AI აგენტებს კოდის უსაფრთხო გარემოში გასაშვებად ემსახურება. „Sandbox\" ნიშნავს, რომ AI-ს კოდი იზოლირებულ კონტეინერში სრულდება — host სისტემაზე წვდომა, ქსელის ბოროტად გამოყენება ან არასასურველი ფაილების შეცვლა გამორიცხულია. Python, Java, JavaScript, C# — ოთხი ძირითადი ენა მხარდაჭერილია. ღია კოდი, MIT ლიცენზიით; Alibaba Cloud-ის კომერციული sandbox სერვისის ოპენ სორს ვარიანტია.",
+      "starsNumeric": 10000,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "OpenSpace",
+      "url": "https://github.com/HKUDS/OpenSpace",
+      "stars": "5.7K",
+      "description": "OpenSpace არის HKUDS-ის Python ფრეიმვორკი AI აგენტების თვითგანვითარებისთვის — AUTO-FIX, AUTO-IMPROVE, AUTO-LEARN მექანიზმებით. აგენტები ახალ სიტუაციებიდან ნასწავლ „უნარებს\" ერთმანეთს უზიარებენ distributed skill library-ის მეშვეობით. benchmark-ების მიხედვით baseline-ზე 4.2-ჯერ მაღალ შედეგს აჩვენებს 46%-ით დაბალი ხარჯებით. HKUDS nanobot-ისა და DeepTutor-ის ეკოსისტემის ნაწილია. 2026 წლის მარტიდან 5,6K ვარსკვლავი — კვლევით AI მიმართულებებში ზრდის ტემპი შთამბეჭდავია.",
+      "starsNumeric": 5700,
+      "categorySlug": "frameworks",
+      "categoryEmoji": "🧬",
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+    },
+    {
+      "name": "OpenClaw",
+      "url": "https://github.com/openclaw/openclaw",
+      "stars": "362K",
+      "description": "OpenClaw არის TypeScript-ის პერსონალური AI ასისტენტი, რომელიც ნებისმიერ ოპერაციულ სისტემასა და პლატფორმაზე მუშაობს. WhatsApp, Telegram, Slack, Discord, iMessage — 20+ არხი ერთი AI backend-ით ემსახურება. ხმოვანი ინტერფეისი, Canvas (ვიზუალური სამუშაო სივრცე) და real-time ინტერნეტის ძიება ჩაშენებულია. TypeScript-ში, 362K ვარსკვლავი — ეს კატეგორიის ყველაზე ვარსკვლავიანი პროექტია. ინდივიდუალური მომხმარებლებისთვის ან მცირე გუნდებისთვის, ვინც ყველა კომუნიკაციის არხი ერთი AI-ით მართოს, მოსახერხებელი გადაწყვეტაა.",
+      "starsNumeric": 362000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "n8n",
+      "url": "https://github.com/n8n-io/n8n",
+      "stars": "185K",
+      "description": "n8n არის TypeScript-ში დაწერილი fair-code ავტომატიზაციის პლატფორმა 400+ ინტეგრაციით, სადაც ვიზუალური no-code builder custom JavaScript/Python კოდთან ერთად მუშაობს. Gmail, Slack, Airtable, ყველა მთავარი ღრუბელი სერვისი და AI provider-ი node-ების სახით ხელმისაწვდომია. self-hosted ან cloud deployment — fair-code ლიცენზია კომერციულ გამოყენებას self-hosted სახით ნებას რთავს. 185K ვარსკვლავით Zapier-ის ყველაზე პოპულარული ღია ალტერნატივაა; AI Pulse Georgia-ს ინფრასტრუქტურის ნაწილია (aipulsegeorgia2025.app.n8n.cloud).",
+      "starsNumeric": 185000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Langflow",
+      "url": "https://github.com/langflow-ai/langflow",
+      "stars": "147K",
+      "description": "Langflow არის Python-ის ვიზუალური პლატფორმა AI აგენტებისა და workflow-ების drag-and-drop ინტერფეისით ასაშენებლად — კოდის გარეშე. LangChain-ის კომპონენტები გრაფიკული ბლოკების სახით ხდება ხელმისაწვდომი: LLM-ები, vector stores, agents, tools ერთმანეთს მიებმება. MCP მხარდაჭერა, 100+ ინტეგრაცია. DataStax-ის მიერ შეძენილია. Python-ის backend, 20,000+ ორგანიზაცია production-ში იყენებს. ვინც Python-ის სტეკს ამჯობინებს და ვიზუალური AI builder სჭირდება, Langflow ოპტიმალური არჩევანია.",
+      "starsNumeric": 147000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Dify",
+      "url": "https://github.com/langgenius/dify",
+      "stars": "138K",
+      "description": "Dify არის production-ready პლატფორმა AI აგენტების, chatbot-ებისა და RAG-ზე დაფუძნებული სისტემების ასაშენებლად ვიზუალური ინტერფეისით. ჩატბოტები, ვორქფლოუები, knowledge bases, text generators — ოთხი ძირითადი application ტიპი GUI-დან კონფიგურირდება. 138K ვარსკვლავით GitHub-ის ერთ-ერთი ყველაზე ვარსკვლავიანი AI პროექტია. Google Search, DALL-E, 100+ ინსტრუმენტი ჩაშენებულია; self-hosted ან Dify Cloud. კომპანიებისთვის, ვინც AI produkts-ს კოდის სერიოზული ინვესტიციის გარეშე production-ში ქონს, ეს ძლიერი გადაწყვეტაა.",
+      "starsNumeric": 138000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Open WebUI",
+      "url": "https://github.com/open-webui/open-webui",
+      "stars": "133K",
+      "description": "Open WebUI არის ChatGPT-ის სტილის AI ინტერფეისი, რომელიც შენს საკუთარ სერვერზე ან კომპიუტერზე ეშვება — ყველა მონაცემი ლოკალურია, ღრუბელში არაფერი მიდის. Ollama-ს, OpenAI API-ის, Claude-ის, Gemini-სა და ათეულობით სხვა provider-ის მხარდაჭერა ჩაშენებულია. RAG (საკუთარი დოკუმენტების კითხვა), ხმოვანი ზარები, agent builder, multi-user auth — ყველა ფუნქცია ერთ სამართავ panel-ში. 355,000+ კომუნიტის წევრი; 133K ვარსკვლავი. ორგანიზაციებისთვის, ვინც privacy-first AI-ს ქმნის, defacto ინსტრუმენტია.",
+      "starsNumeric": 133000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "gpt4all",
+      "url": "https://github.com/nomic-ai/gpt4all",
+      "stars": "77K",
+      "description": "GPT4All არის Nomic AI-ის C++-ში დაწერილი ინსტრუმენტი ლოკალური LLM-ების ნებისმიერ მოწყობილობაზე გასაშვებად — Mac, Windows, Linux, GPU-ს გარეშეც. desktop GUI, Python SDK და REST API ერთ პაკეტში გვთავაზობს. **⚠️ აქტიური განვითარება შეჩერებულია**: ბოლო GitHub commit 2025 წლის მაისია, Nomic AI ფოკუსი გადაიტანა სხვა პროდუქტებზე. Ollama-ს ეკოსისტემამ წინ გაუსწრო. მიუხედავად ამისა, desktop UI-ის სიმარტივე ჯერ კიდევ უნიკალური ღირებულებაა არატექნიკური მომხმარებლებისთვის — თუ GUI გჭირდება და რეგულარული განახლება მნიშვნელოვანი არაა, მაინც ვარგისია.",
+      "starsNumeric": 77000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "LobeChat",
+      "url": "https://github.com/lobehub/lobe-chat",
+      "stars": "75K",
+      "description": "LobeChat არის TypeScript/Next.js-ის ღია ChatGPT ალტერნატივა, სადაც ნებისმიერი LLM სერვერი — OpenAI, Claude, Gemini, Ollama, Mistral — ერთ ინტერფეისში ხდება ხელმისაწვდომი. multi-agent collaboration, plugin marketplace, ხმოვანი ჩეთი, დოკუმენტების ანალიზი, knowledge base — ყველა ფუნქცია self-hosted-ში ან Lobe Cloud-ში. privacy-first, multi-user auth ჩაშენებული. 75K ვარსკვლავი, მსოფლიოში ასობით self-hosted instance. ორგანიზაციებისთვის, ვინც ყველა LLM-ს ერთ კონტროლირებად ინტერფეისში ქონს, LobeChat სრული გადაწყვეტაა.",
+      "starsNumeric": 75000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "AnythingLLM",
+      "url": "https://github.com/Mintplex-Labs/anything-llm",
+      "stars": "58K",
+      "description": "AnythingLLM არის Mintplex Labs-ის JavaScript all-in-one AI პლატფორმა — RAG, agents, chat, multi-user auth და 20+ LLM provider ერთ desktop ან server აპლიკაციაში. განსაკუთრებული ღირებულება desktop ვერსიაა: ინსტალაციის შემდეგ კომპლექსური კონფიგურაციის გარეშე მუშაობს, ყველა მონაცემი ლოკალური რჩება. საკუთარი კომპანიის დოკუმენტების (HR, legal, technical) AI-ით შესამოწმებლად privacy-first გადაწყვეტაა. 58K ვარსკვლავი; კონკურენტებს (Dify, Open WebUI) „setup-free\" გამოცდილებით სჯობნის.",
+      "starsNumeric": 58000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Paperclip",
+      "url": "https://github.com/paperclipai/paperclip",
+      "stars": "58K",
+      "description": "Paperclip არის TypeScript-ის ღია კოდის AI ორკესტრაციის პლატფორმა ბიზნეს პროცესების ავტომატიზაციისთვის — „zero-human companies\" (ადამიანის მინიმალური მონაწილეობით მუშაობა) ფილოსოფიით. AI აგენტების გუნდს აწყობ, ბიუჯეტის ლიმიტებს, audit log-ს და progress tracking-ს ჩაშენებული მართვის panel-ით. 2026 წლის მარტში გამოშვებული, სწრაფად 58K ვარსკვლავი დააგროვა. ბიზნეს ხელმძღვანელებისთვის, ვინც AI automation-ს ეფექტურ ფინანსურ კონტროლთან ერთად ქმნის.",
+      "starsNumeric": 58000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "MiroFish",
+      "url": "https://github.com/666ghj/MiroFish",
+      "stars": "57K",
+      "description": "MiroFish არის Python-ის „გროვის ინტელექტის\" (swarm intelligence) სიმულაციის ძრავა, სადაც ათასობით AI აგენტი ინდივიდუალური პიროვნებითა და მეხსიერებით სიმულირდება ბაზრის ან სხვა სისტემების პროგნოზირებისთვის. თითოეულ აგენტს განსხვავებული ქცევის მოდელი აქვს, კოლექტიური გადაწყვეტილება კი ემერჯენტულია — არარომელი ცენტრალური „ტვინი\" არ არსებობს. Docker-ით ადვილად ეშვება. ეს არის სიმულაციური/კვლევითი ინსტრუმენტი, არა agent builder framework.",
+      "starsNumeric": 57000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Flowise",
+      "url": "https://github.com/FlowiseAI/Flowise",
+      "stars": "52K",
+      "description": "Flowise არის TypeScript-ის drag-and-drop ვიზუალური AI builder, სადაც LLM-ების, agents-ების, vector stores-ისა და tools-ის კავშირები გრაფიკულ ბლოკებად ერთმანეთზე მიებმება. LangChain.js-ის კომპონენტებზეა დაშენებული — JavaScript/Node.js სტეკი. Langflow-ის (Python) პარალელი, 100+ ინტეგრაციით. self-hosted ან Flowise Cloud. non-technical მომხმარებლებიც შეძლებენ AI სამუშაო ნაკადების ვიზუალურ კომპოზიციას; Node.js-ს უპირატესობა მქონე გუნდებისთვის Langflow-ის ანალოგია.",
+      "starsNumeric": 52000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Jan",
+      "url": "https://github.com/janhq/jan",
+      "stars": "42K",
+      "description": "Jan არის TypeScript-ის open-source desktop AI ასისტენტი Mac/Windows/Linux-ისთვის, 100% offline-ში მუშაობს — ინტერნეტი არ სჭირდება, ღრუბელი არ გამოიყენება. Llama, Mistral, Phi, Qwen მოდელები ერთი click-ით ჩამოიტვირთება. Cortex backend-ი სიჩქარისა და resource efficiency-სთვის. OpenAI-compatible local API სხვა ხელსაწყოებთან ინტეგრაციისთვის. 42K ვარსკვლავი; ვინც ქართული მომხმარებლის მონაცემების privacy-ს ანიჭებს პრიორიტეტს, Jan ყველაზე გასაგები ინტერფეისი ლოკალური AI-სთვის.",
+      "starsNumeric": 42000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "LibreChat",
+      "url": "https://github.com/danny-avila/LibreChat",
+      "stars": "35K",
+      "description": "LibreChat არის TypeScript-ის self-hosted ChatGPT კლონი, რომელიც frontierr-ის ყველა LLM-ს — Claude, GPT-5, o3, DeepSeek, Gemini, Mistral, Groq, Azure OpenAI, Vertex AI, OpenRouter — ერთ ინტერფეისში აერთებს. DALL-E-3, Code Interpreter, message search, MCP, OpenAPI Actions, multi-user auth ჩაშენებულია. TypeScript-ში, MIT ლიცენზიით, სწრაფი განვითარება ინახავს. კომპანიებისთვის, ვინც ყველა AI მოდელს ერთ კონტროლირებად, audit-ირებად ინტერფეისში სჭირდება — LibreChat ყველაზე feature-complete self-hosted გამოსავალია.",
+      "starsNumeric": 35000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Khoj",
+      "url": "https://github.com/khoj-ai/khoj",
+      "stars": "34K",
+      "description": "Khoj არის Python-ის self-hostable „AI second brain\" — პერსონალური AI ასისტენტი, რომელიც ვებს, შენს დოკუმენტებსა და შენახულ ინფორმაციას ეძებს ერთდროულად. custom agents, scheduled automations, deep research mode, Notion, iMessage ინტეგრაცია ჩაშენებულია. ნებისმიერი online ან local LLM (GPT, Claude, Gemini, Llama, Qwen, Mistral) backend-ად გამოიყენება. 2021 წლიდან განვითარდება — ერთ-ერთი ყველაზე დიდხნიანი პროექტი ამ სიაში. საკუთარი ცოდნის ბაზის, კვლევის სამუშაო ნაკადებისა და ყოველდღიური ამოცანების ავტომატიზაციისთვის.",
+      "starsNumeric": 34000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Vane (ex-Perplexica)",
+      "url": "https://github.com/ItzCrazyKns/Perplexica",
+      "stars": "33K",
+      "description": "Vane (ყოფილი **Perplexica**; repo URL ჯერ ძველ სახელს ინახავს, ხოლო repo-ს მიმდინარე description უკვე „Vane is an AI-powered answering engine\") — TypeScript-ის ღია კოდის AI საძიებო ძრავა, Perplexity AI-ს self-hosted ალტერნატივა. ინტერნეტში ეძებს, შედეგებს ამუშავებს და პასუხს წყაროებიანად გასცემს, ჩვეულებრივ ბრაუზერ-ძიებაზე ბევრად უფრო კონტექსტუალურად. Ollama-ს ლოკალური მოდელებით მუშაობს. 33K ვარსკვლავი; შენი მონაცემების გარეთ გასვლის გარეშე web research-ისთვის — Perplexity-ს ანალოგი ყველაზე ახლო, self-hosted.",
+      "starsNumeric": 33000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Activepieces",
+      "url": "https://github.com/activepieces/activepieces",
+      "stars": "21K",
+      "description": "Activepieces არის TypeScript-ის AI-first workflow automation პლატფორმა — n8n-ის ღია ალტერნატივა, 400+ MCP სერვერის native მხარდაჭერით. AI agents, MCP integrations, visual workflow builder ერთ პაკეტში ერთიანდება. self-hosted ან cloud, MIT ლიცენზია. n8n-ისგან განსხვავდება MCP-first მიდგომით — თუ AI agents-ის MCP-ის ეკოსისტემა გსურს ვიზუალური ავტომატიზაციასთან, Activepieces ამ კომბინაციის სპეციფიკური გამოსავალია.",
+      "starsNumeric": 21000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "DeepTutor",
+      "url": "https://github.com/HKUDS/DeepTutor",
+      "stars": "21K",
+      "description": "DeepTutor არის HKUDS-ის Python-ის AI სასწავლო ასისტენტი, სპეციალურად სტუდენტებისა და მკვლევარებისთვის. Chat, Deep Solve, Quiz Generation, Deep Research და Math Animator — 5 სარეჟიმო ერთ პლატფორმაზე. RAG (საკუთარი სასწავლო მასალების ჩართვა), ვებ ძიება, სამეცნიერო ნაშრომების ძიება, კოდის ექსეკუცია ჩაშენებულია. TutorBot-ების შექმნა მდგრადი მეხსიერებითა და „პიროვნებით\" — ყოველ სტუდენტზე მორგებული სასწავლო გამოცდილება. HKUDS ეკოსისტემის (nanobot, OpenSpace) ნაწილია.",
+      "starsNumeric": 21000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Multica",
+      "url": "https://github.com/multica-ai/multica",
+      "stars": "20K",
+      "description": "Multica არის TypeScript-ის ღია კოდის managed agents პლატფორმა, რომელიც AI კოდირების აგენტებს (coding agents) რეალური გუნდის წევრებად აქცევს. ამოცანების მინიჭება, პროგრესის მონიტორინგი, გამოცდილების დაგროვება (compounding skills) — ყოველი ციკლით AI უფრო კარგად ასრულებს ამ გუნდის სპეციფიკურ ამოცანებს. 2026 წლის იანვარში გამოშვებული, სწრაფად 20K ვარსკვლავამდე გაიზარდა. ტექნიკური გუნდებისთვის, ვინც Claude Code-ის, Codex-ის ან სხვა coding agent-ების სამართავ ინსტრუმენტს ეძებს.",
+      "starsNumeric": 20000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Fincept Terminal",
+      "url": "https://github.com/Fincept-Corporation/FinceptTerminal",
+      "stars": "13K",
+      "description": "Fincept Terminal არის Python-ში დაწერილი ღია კოდის ფინანსური ტერმინალი, Bloomberg-ის ალტერნატივა. 100+ მონაცემთა კონექტორი (Yahoo Finance, FRED, IMF, World Bank, Polygon) და 20+ AI ინვესტორ-პერსონა მრავალ LLM პროვაიდერთან (OpenAI, Anthropic, Gemini, Groq, Ollama) ერთიანდება. DCF მოდელები, პორტფელის ოპტიმიზაცია, VaR/Sharpe მეტრიკა, კრიპტო WebSocket, ალგო-ტრეიდინგი ჩაშენებულია. Python-ში (README-ში ცდომილებით C++20/Qt6 იყო მითითებული). ინდივიდუალური ინვესტორებისა და მცირე ინვესტიციური გუნდებისთვის, ვისაც ინსტიტუციური ინსტრუმენტები სჭირდება ინსტიტუციური ფასის გარეშე.",
+      "starsNumeric": 13000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Rowboat",
+      "url": "https://github.com/rowboatlabs/rowboat",
+      "stars": "13K",
+      "description": "Rowboat არის TypeScript-ის ღია კოდის AI „კოლეგა\" მდგრადი მეხსიერებით — AI, რომელიც სამუშაო კონტექსტს ინახავს სესიებს შორის. OpenAI API-ზე დაშენებული, self-hosted, ღრუბელი სურვილისამებრ. 2025 წლის იანვრიდან 13K ვარსკვლავი; ამ კატეგორიის ახალი შემოსვლა. მცირე გუნდებისთვის, ვინც გრძელვადიანი AI ასისტენტი სჭირდება, რომელიც მათ სამუშაო კონტექსტს, გადაწყვეტილებებსა და ამოცანებს ახსოვს.",
+      "starsNumeric": 13000,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "Feynman",
+      "url": "https://github.com/getcompanion-ai/feynman",
+      "stars": "5.8K",
+      "description": "Feynman არის ღია კოდის AI კვლევის აგენტი, სადაც 4 სპეციალიზებული sub-agent (Researcher, Reviewer, Writer, Verifier) პარალელურად მუშაობს სამეცნიერო ინვესტიგაციის პროცესში. `/deepresearch`, `/lit`, `/audit`, `/replicate`, `/compare` სლეშ-ბრძანებები ყოველი სამუშაო ნაკადისთვის ხელმისაწვდომია. ყოველი დასკვნა პირდაპირ წყაროს მიუთითებს — ნაშრომს, დოკს ან რეპოს — ჰალუცინაციის რისკის მინიმუმამდე დასაყვანად. TypeScript-ში, ლოკალური მოდელებით (Ollama, LM Studio) ან cloud-ით მუშაობს; macOS/Linux/Windows ინსტალერი ხელმისაწვდომია.",
+      "starsNumeric": 5800,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "agentic-inbox",
+      "url": "https://github.com/cloudflare/agentic-inbox",
+      "stars": "1.3K",
+      "description": "agentic-inbox **Cloudflare-ის ოფიციალური** self-hosted ელფოსტის კლიენტია ჩაშენებული AI agent-ით, რომელიც მთლიანად Cloudflare Workers-ზე (edge network) მუშაობს. AI ავტომატურად ალაგებს წერილებს, საპასუხო ტექსტს სწერს, მნიშვნელოვნობის მიხედვით ასორტირებს — ინბოქსის „თვით-მართვადი\" ვერსია. TypeScript-ში, 2026 წლის 10 აპრილს გამოიცა. Gmail-ის AI ფუნქციების privacy-first ღია ალტერნატივა — შენი domain, შენი მონაცემები, Cloudflare-ის სიჩქარე. ქართული ბიზნესებისთვის, ვინც domain email-ს უკვე Cloudflare-ზე ინახავს.",
+      "starsNumeric": 1300,
+      "categorySlug": "business",
+      "categoryEmoji": "💼",
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+    },
+    {
+      "name": "RAGFlow",
+      "url": "https://github.com/infiniflow/ragflow",
+      "stars": "78K",
+      "description": "RAGFlow — ღია კოდის RAG ძრავა, რომელიც AI-ს შენს დოკუმენტებში ზუსტი ინფორმაციის მოძიების საშუალებას აძლევს. პრობლემას წყვეტს, რომელიც ყველა „AI chatbot\"-ს ახასიათებს: მოდელი ხშირად გამოიგონებს პასუხებს — RAGFlow კი ჯერ ეძებს შენს ფაილებში, შემდეგ პასუხობს. Python-ში დაწერილი, მხარს უჭერს PDF, Word, Excel, PowerPoint, HTML ფორმატებს და მოიცავს ჩაშენებულ agent workflow-ს. InfiniFlow-ის კომერციული პლატფორმის საფუძველია — კომპანიები ცოდნის ბაზებისა და AI-ზე დაფუძნებული მხარდაჭერის სისტემების ასაწყობად იყენებენ.",
+      "starsNumeric": 78000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "mem0",
+      "url": "https://github.com/mem0ai/mem0",
+      "stars": "53K",
+      "description": "mem0 — AI აგენტებისა და chatbot-ებისთვის შექმნილი უნივერსალური მეხსიერების ფენა. წყვეტს ძირეულ პრობლემას: სტანდარტული LLM-ები ყოველ საუბარს ნულიდან იწყებენ — mem0 კი ინახავს მომხმარებლის პრეფერენციებს, წარსულ ინტერაქციებსა და კონტექსტს. Python SDK, REST API და managed cloud სერვისი ხელმისაწვდომია. LangChain-თან, LlamaIndex-თან და OpenAI Agents-თან ინტეგრირდება. Perplexity, Pika, Wordware და სხვა პროდუქციის სისტემები mem0-ს ოპერაციული მეხსიერებისთვის იყენებენ.",
+      "starsNumeric": 53000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "MemPalace",
+      "url": "https://github.com/milla-jovovich/mempalace",
+      "stars": "49K",
+      "description": "MemPalace — ღია კოდის AI მეხსიერების სისტემა, რომელიც benchmark-ებზე ყველაზე მაღალ შეფასებას იღებს ანალოგიურ უფასო გადაწყვეტებს შორის. Python-ში დაწერილი, AI აგენტების გრძელვადიანი მეხსიერებისა და კონტექსტის შესანახად. სრულიად უფასო და self-hosted, API key-ები არ სჭირდება. 2026 წლის აპრილში გამოჩნდა და სწრაფად მოიპოვა ტრექშენი AI agent builders-ის საზოგადოებაში.",
+      "starsNumeric": 49000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "LlamaIndex",
+      "url": "https://github.com/run-llama/llama_index",
+      "stars": "48K",
+      "description": "LlamaIndex — Python-ის ფრეიმვორკი, რომელიც AI-ს ნებისმიერ მონაცემთა წყაროსთან — ფაილები, მონაცემთა ბაზები, API-ები, ვებ გვერდები — სამუშაოდ ამზადებს. პირველ რიგში RAG pipeline-ების ასაწყობად გამოიყენება: დოკუმენტების indexing-იდან ძიებამდე და პასუხის გენერაციამდე ერთ ჩარჩოში. 300-ზე მეტი ინტეგრაცია — OpenAI, Anthropic, Hugging Face, Pinecone, Weaviate, PostgreSQL. 2024 წლიდან OCR-ისა და document agent-ების პლატფორმადაც განვითარდა. Python-ში დაწერილი, Apache 2.0 ლიცენზია, საწარმოო გამოყენებისთვის მომზადებული.",
+      "starsNumeric": 48000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Milvus",
+      "url": "https://github.com/milvus-io/milvus",
+      "stars": "43K",
+      "description": "Milvus — cloud-native ვექტორული მონაცემთა ბაზა, რომელიც მილიარდობით embedding-ის შენახვასა და სწრაფ similarity search-ზეა ოპტიმიზებული. RAG სისტემებში, რეკომენდაციის ძრავებში და სემანტიკური ძიების applikaciebi-ში vector store-ის სტანდარტული არჩევანია. Go-ში და C++-ში დაწერილი, distributed architecture-ით, Kubernetes-ზე deploy-ისთვის. LF AI Foundation-ის პროექტი, Zilliz კომპანიის მხარდაჭერით. NVIDIA, Roblox, Shopee და Salesforce საწარმოო გარემოში იყენებენ.",
+      "starsNumeric": 43000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "LightRAG",
+      "url": "https://github.com/hkuds/lightrag",
+      "stars": "34K",
+      "description": "LightRAG — სწრაფი RAG სისტემა, რომელიც ჩვეულებრივი vector similarity search-ს knowledge graph-ით აერთებს. სტანდარტული RAG-ი სიტყვებს ეძებს — LightRAG კი ცნებებს შორის კავშირებსაც ანალიზებს, რაც კომპლექსური კითხვებზე გაცილებით ზუსტ პასუხს იძლევა. Python-ში დაწერილი, Hong Kong University-ის Data Science ლაბორატორიის მიერ, EMNLP 2025-ზე გამოქვეყნებული სამეცნიერო ნაშრომით გამყარებული. Neo4j, NetworkX ან ჩაშენებული graph backend-ით მუშაობს.",
+      "starsNumeric": 34000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Qdrant",
+      "url": "https://github.com/qdrant/qdrant",
+      "stars": "30K",
+      "description": "Qdrant — Rust-ში დაწერილი high-performance ვექტორული მონაცემთა ბაზა, AI-ის შემდეგი თაობის semantic search-ისა და RAG სისტემებისთვის. Rust-ის გამო გამოირჩევა სიჩქარით, მცირე memory footprint-ით და thread safety-ით. payload filtering, quantization, sparse vector-ების მხარდაჭერა და horizontal scaling ჩაშენებულია. Docker-ით ადვილად გაუშვებ ლოკალურად, managed Qdrant Cloud ასევე ხელმისაწვდომია. Python, TypeScript, Go, Rust SDK-ებით.",
+      "starsNumeric": 30000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Chroma",
+      "url": "https://github.com/chroma-core/chroma",
+      "stars": "27K",
+      "description": "Chroma — AI-ისთვის შექმნილი open-source embedding database, რომელიც semantic search-ისა და RAG pipeline-ების ასაწყობად ყველაზე ხშირად გამოიყენება. LangChain-ისა და LlamaIndex-ის default vector store-ია — ამიტომ საუკეთესო შესავალი point-ია embedding-ებთან მუშაობისთვის. embedded რეჟიმში SQLite-ზე, standalone სერვერად ან Chroma Cloud-ზე ეშვება. Python-ის 5 სტრიქონით მუშა RAG სისტემა დგება. Rust-ში დაწერილი ბირთვით, YC W23-ის კომპანია, Series A დაფინანსებული.",
+      "starsNumeric": 27000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Graphiti",
+      "url": "https://github.com/getzep/graphiti",
+      "stars": "25K",
+      "description": "Graphiti — AI აგენტებისთვის შექმნილი real-time knowledge graph ძრავა, Zep AI-ს (YC W24) მიერ. სტანდარტული vector-based RAG-ისგან განსხვავებით, Graphiti ინახავს ფაქტების დროით კონტექსტს — ანუ იცის „როდის\" შეიცვალა ინფორმაცია. bi-temporal მოდელი event time-სა და ingestion time-ს ცალ-ცალკე ინახავს, entity-ებსა და relations-ს კი LLM ავტომატურად ამოიღებს ტექსტიდან. Neo4j ან FalkorDB backend-ზე ეშვება, native MCP integration-ით Claude Desktop-ში, Cursor-სა და Cline-ში გამოყენება შეიძლება.",
+      "starsNumeric": 25000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Letta",
+      "url": "https://github.com/letta-ai/letta",
+      "stars": "22K",
+      "description": "Letta — stateful AI აგენტების პლატფორმა, რომელიც ყოფილ MemGPT პროექტზეა დაფუძნებული. ჩვეულებრივი AI chatbot-ისგან განსხვავებით, Letta-ს აგენტებს გრძელვადიანი მეხსიერება აქვთ: working memory (მიმდინარე კონტექსტი) და archival memory (გრძელვადიანი შენახვა) — კვირები, თვეები. UC Berkeley-ს მკვლევართა გუნდი დააარსა. OpenAI API-თავსებადი REST API, self-hosted deploy-ისთვის. long-running agents-ისთვის, სადაც მეხსიერება სასიცოცხლო მნიშვნელობისაა.",
+      "starsNumeric": 22000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "RAG-Anything",
+      "url": "https://github.com/HKUDS/RAG-Anything",
+      "stars": "18K",
+      "description": "RAG-Anything — all-in-one მულტიმოდალური RAG ფრეიმვორკი, LightRAG-ის შემქმნელი Hong Kong University-ის Data Science ლაბორატორიისგან. სტანდარტური RAG სისტემები მხოლოდ ტექსტს ამუშავებენ — RAG-Anything კი ერთ pipeline-ში ათავსებს ტექსტს, სურათებს, ცხრილებს, დიაგრამებს და სხვა ფორმატებს. Python-ში დაწერილი, \"RAG-Anything: All-in-One RAG Framework\" სამეცნიერო ნაშრომის განხორციელებაა. LightRAG-ის graph-based reasoning-ს multimodal შეყვანაზე ავრცელებს.",
+      "starsNumeric": 18000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "gbrain",
+      "url": "https://github.com/garrytan/gbrain",
+      "stars": "10K",
+      "description": "gbrain — TypeScript-ში დაწერილი AI აგენტის პერსონალური „ტვინი\", რომელიც ელ-ფოსტას, კალენდარს, შეხვედრებს და იდეებს ერთ ადგილზე აგროვებს და ინახავს. ჰიბრიდული ძიება (ვექტორული + keyword) სწრაფ და ზუსტ retrieval-ს უზრუნველყოფს. MCP სერვერი Claude-ისა და სხვა LLM-ებისთვის ჩაშენებულია. ლოკალურად PGLite-ით ან Supabase-ით ეშვება. 2026 წლის აპრილში გამოჩნდა, სწრაფად მოიპოვა ტრექშენი AI personal assistant builders-ში.",
+      "starsNumeric": 10000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Hindsight",
+      "url": "https://github.com/vectorize-io/hindsight",
+      "stars": "10K",
+      "description": "Hindsight — AI აგენტის მეხსიერების სისტემა Vectorize-ისგან, რომელიც დროთა განმავლობაში სწავლობს და თავად უმჯობესდება. ჩვეულებრივი RAG სისტემებისგან განსხვავებით, Hindsight ამოიცნობს შაბლონებს წარსულ ინტერაქციებში და მომდევნო პასუხებს უფრო რელევანტურს ხდის. Python-ში დაწერილი, arXiv-ზე გამოქვეყნებული სამეცნიერო ნაშრომით გამყარებული. long-running agents-ისთვის, სადაც მეხსიერების ხარისხი დროთა განმავლობაში უნდა გაუმჯობესდეს.",
+      "starsNumeric": 10000,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Crawl4AI RAG",
+      "url": "https://github.com/coleam00/mcp-crawl4ai-rag",
+      "stars": "2.1K",
+      "description": "mcp-crawl4ai-rag — MCP სერვერი, რომელიც ვებ crawling-სა და RAG-ს ერთ pipeline-ში აერთებს AI კოდინგ ასისტენტებისა და აგენტებისთვის. AI ინტერნეტიდან ინფორმაციას Crawl4AI-ით აგროვებს, Supabase-ის ვექტორულ მონაცემთა ბაზაში ინახავს და შემდეგ ამ კონტექსტზე დაყრდნობით პასუხობს კითხვებს. Python-ში დაწერილი, Claude, Cursor, Cline-ში MCP-ით გამოიყენება. მცირე, ფოკუსირებული ხელსაწყო, რომელიც ახალი AI Agent workflow-ების სწრაფ პროტოტიპირებისთვის გამოდგება.",
+      "starsNumeric": 2100,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Prism MCP",
+      "url": "https://github.com/dcostenco/prism-mcp",
+      "stars": "129",
+      "description": "Prism MCP — AI აგენტებისთვის შექმნილი HIPAA-სტანდარტის კოგნიტური არქიტექტურა, MCP პროტოკოლით. ჩაშენებული on-device LLM (prism-coder:7b), Hebbian learning-ი და ACT-R spreading activation-ი მეხსიერების ორგანიზაციას ადამიანის შემეცნებითი მოდელის მსგავსად ახდენს. API key-ები არ სჭირდება — სრულად ლოკალურად მუშაობს. multi-agent Hivemind სინქრონიზაცია, adversarial evaluation და ვიზუალური dashboard ჩაშენებულია. TypeScript-ში დაწერილი, ექიმებისა და regulated industries-ისთვის ვარგისი კონფიდენციალობის გათვალისწინებით.",
+      "starsNumeric": 129,
+      "categorySlug": "memory",
+      "categoryEmoji": "🧠",
+      "categoryGeorgian": "მეხსიერება და RAG"
+    },
+    {
+      "name": "Ollama",
+      "url": "https://github.com/ollama/ollama",
+      "stars": "169K",
+      "description": "Ollama — ყველაზე მარტივი გზა LLM-ების ლოკალურად გასაშვებად. ერთი ბრძანებით — `ollama run llama4` — და Llama, Mistral, Qwen, DeepSeek, Gemma, Phi და ასობით სხვა მოდელი მზადაა. Go-ში დაწერილი, macOS, Windows, Linux-ზე მუშაობს, GPU-ს გარეშეც. REST API ჩაშენებულია — ნებისმიერი OpenAI SDK-ის კლიენტი Ollama-სთანაც მუშაობს base URL-ის შეცვლით. პირადი მონაცემები კომპიუტერს არ ტოვებს, სრულად უფასოა.",
+      "starsNumeric": 169000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Transformers",
+      "url": "https://github.com/huggingface/transformers",
+      "stars": "159K",
+      "description": "Hugging Face Transformers — state-of-the-art machine learning მოდელების სტანდარტული framework, Python-ში. Llama, Mistral, Qwen, DeepSeek, Gemma, Phi — პრაქტიკულად ყველა ცნობილი ღია LLM ამ ბიბლიოთეკის მეშვეობით ეშვება. ტექსტის, ხმოვანი, ვიზუალური და მულტიმოდალური მოდელები ერთ API-ში. PyTorch, TensorFlow და JAX backend-ებს უჭერს მხარს. Hugging Face-ის კომპანია მართავს — AI კვლევისა და engineering-ის ინდუსტრიული სტანდარტი.",
+      "starsNumeric": 159000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "ComfyUI",
+      "url": "https://github.com/comfy-org/ComfyUI",
+      "stars": "109K",
+      "description": "ComfyUI — diffusion model-ებით სურათებისა და ვიდეოების გენერაციის ყველაზე მოქნილი პლატფორმა, node-based ვიზუალური ინტერფეისით. პროცესებს ბლოკ-სქემის სახით ვხატავთ — ყოველი node ერთ ოპერაციას ასრულებს (sampling, upscaling, LoRA გამოყენება, inpainting). Python-ში დაწერილი, REST API ჩაშენებული, 1 000-ზე მეტი community extension ხელმისაწვდომია. Stable Diffusion, FLUX, SDXL, Wan, CogVideoX და სხვა მოდელები მხარდაჭერილია. AI ხელოვნებისა და ვიდეო კონტენტის პროფესიონალებს შორის ინდუსტრიული სტანდარტია.",
+      "starsNumeric": 109000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "llama.cpp",
+      "url": "https://github.com/ggml-org/llama.cpp",
+      "stars": "106K",
+      "description": "llama.cpp — LLM inference C/C++-ში, Georgi Gerganov-ის მიერ. ძირითადი ღირსება: GPU-ს გარეშე, CPU-ზე, მინიმალური hardware-ზე ეშვება. GGUF — კვანტიზებული მოდელების ინდუსტრიული ფორმატი — სწორედ ამ პროექტს შემოაქვს. Ollama, LM Studio და LocalAI შიგნით llama.cpp-ს იყენებენ. ggml-org ორგანიზაციაში ცხოვრობს (ყოფილ ggerganov/llama.cpp-დან გადავიდა). macOS, Linux, Windows, Android-ზე მუშაობს, ARM ჩიპებზე ოპტიმიზებული.",
+      "starsNumeric": 106000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "vLLM",
+      "url": "https://github.com/vllm-project/vllm",
+      "stars": "77K",
+      "description": "vLLM — LLM-ების high-throughput inference-ისა და serving-ის ძრავა, Python-ში. PagedAttention ტექნოლოგია GPU მეხსიერებას ოპერაციული სისტემის paging-ის პრინციპით მართავს, რაც concurrent request-ების throughput-ს მნიშვნელოვნად ზრდის. OpenAI-compatible REST API ჩაშენებულია — production deployment-ისთვის ოპტიმიზებულია. UC Berkeley-ს Sky Lab-ში დაიბადა, ახლა independent project-ია. Google, Microsoft, Mistral AI, Cohere და სხვა კომპანიები production serving-ისთვის იყენებენ.",
+      "starsNumeric": 77000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Stable Diffusion",
+      "url": "https://github.com/CompVis/stable-diffusion",
+      "stars": "72K",
+      "description": "Stable Diffusion — latent diffusion model, რომელმაც 2022 წელს ტექსტიდან სურათის გენერაცია ყველასთვის ხელმისაწვდომი გახადა. CompVis (LMU Munich), Stability AI-ისა და Runway-ის ერთობლივი კვლევის შედეგია. ეს არის original reference implementation — ComfyUI, AUTOMATIC1111 და სხვა UI-ები სწორედ ამ მოდელის ირგვლივ აიგო. Jupyter Notebook-ებში, Python-ში დაწერილი, GPU-ს ესაჭიროება. შენიშვნა: ახალი სურათების გენერაციისთვის დღეს ComfyUI ან FLUX-ს იყენებენ — ეს repo ძირითადად ისტორიული მნიშვნელობისაა.",
+      "starsNumeric": 72000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Unsloth",
+      "url": "https://github.com/unslothai/unsloth",
+      "stars": "62K",
+      "description": "Unsloth — LLM-ების fine-tuning-ისა და ლოკალური გაშვების ხელსაწყო, ვებ ინტერფეისით. Gemma, Qwen, DeepSeek, Llama-ს მსგავსი ღია მოდელები შენს მონაცემებზე გადაწვრთნა სტანდარტულ PyTorch-თან შედარებით 2-ჯერ სწრაფად და 70%-ით ნაკლები GPU მეხსიერებით ხდება. LoRA და QLoRA fine-tuning ჩაშენებული, GGUF-ში export მხარდაჭერილია. Python-ში, Jupyter Notebook-ების გარდა ახლა ვებ UI-ც ხელმისაწვდომია. ერთ GPU-ზე fine-tuning-ისთვის de facto სტანდარტი გახდა.",
+      "starsNumeric": 62000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "whisper.cpp",
+      "url": "https://github.com/ggerganov/whisper.cpp",
+      "stars": "48K",
+      "description": "whisper.cpp — OpenAI-ის Whisper speech-to-text მოდელის C/C++ port, Georgi Gerganov-ის მიერ (llama.cpp-ის შემქმნელი). GPU-ს გარეშეც მუშაობს — CPU-ზე, ARM-ზე, ტელეფონებზეც. 100-ზე მეტ ენაზე transcription-ს ასრულებს, ქართულის ჩათვლით. real-time streaming, speaker diarization, word-level timestamps მხარდაჭერილია. C++ ბიბლიოთეკა Python, Node.js, Go binding-ებითაც ხელმისაწვდომია. podcast-ების, ინტერვიუების, meeting-ების ავტომატური transcription-ისთვის ინდუსტრიული ინსტრუმენტია.",
+      "starsNumeric": 48000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "LocalAI",
+      "url": "https://github.com/mudler/LocalAI",
+      "stars": "45K",
+      "description": "LocalAI — ღია კოდის AI ძრავა, OpenAI API-ის ადგილობრივი ჩამნაცვლებელი. LLM-ები, vision, TTS, STT, image generation, video — ყველაფერი ერთ სერვერში, GPU-ს გარეშე. OpenAI-ის SDK-ები base URL-ის შეცვლით მაშინვე მუშაობს — migration ნულიდან. Go-ში დაწერილი, Docker-ით deploy-ი ადვილია. self-hosted AI-ის ყველაზე სრული ჩამნაცვლებელი OpenAI API-სთვის, კონფიდენციალობისა და air-gapped გარემოებისთვის.",
+      "starsNumeric": 45000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Coqui TTS",
+      "url": "https://github.com/coqui-ai/TTS",
+      "stars": "45K",
+      "description": "Coqui TTS — ღია კოდის deep learning toolkit text-to-speech-ისთვის, Python-ში, კვლევასა და production-ში გამოცდილი. ხმის კლონირება 3-10 წამიანი ნიმუშიდანაა შესაძლებელი. 17-ზე მეტ ენაზე მუშაობს, მრავალი სხვადასხვა TTS არქიტექტურა ჩაშენებულია (VITS, YourTTS, Bark). შენიშვნა: Coqui AI კომპანია 2024 წელს დაიხურა — repo-ს community ინარჩუნებს, მაგრამ აქტიური კომერციული development შეჩერებულია. RealtimeTTS და Bark — აქტიური ალტერნატივები.",
+      "starsNumeric": 45000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Bark",
+      "url": "https://github.com/suno-ai/bark",
+      "stars": "39K",
+      "description": "Bark — Suno AI-ის text-prompted generative audio model. ჩვეულებრივი TTS-ისგან განსხვავებით, Bark ქმნის არა მხოლოდ speech-ს, არამედ სიმღერებს, ხმოვან ეფექტებს, სიცილს, ტირილს, ოხვრასა და სხვა non-verbal ხმებს. 100-ზე მეტ ენაზე მუშაობს. Python/Jupyter-ში, Hugging Face-ზე ხელმისაწვდომი. შენიშვნა: Bark-ის განახლებები შეჩერდა, Suno AI ახლა მუსიკის გენერაციის კომერციულ პლატფორმაზეა ფოკუსირებული — repo community mode-შია. Coqui TTS-ის ალტერნატივა, რომელსაც მეტი expressive range აქვს.",
+      "starsNumeric": 39000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Diffusers",
+      "url": "https://github.com/huggingface/diffusers",
+      "stars": "33K",
+      "description": "Hugging Face Diffusers — state-of-the-art diffusion model-ების Python ბიბლიოთეკა სურათების, ვიდეოების და აუდიოს გენერაციისთვის. Stable Diffusion, FLUX, SDXL, CogVideoX, Wan — ყველა ძირითადი generative model ამ ბიბლიოთეკის მეშვეობით ეშვება. LoRA, ControlNet, IP-Adapter — პოპულარული fine-tuning ტექნიკები ჩაშენებულია. Transformers-ის „diffusion counterpart\" Hugging Face-ისგან, ერთი unified API-ით ყველა გენერაციული მოდელისთვის. AI ხელოვნებაში Python pipeline-ების სტანდარტი.",
+      "starsNumeric": 33000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "SGLang",
+      "url": "https://github.com/sgl-project/sglang",
+      "stars": "26K",
+      "description": "SGLang — LLM-ებისა და მულტიმოდალური მოდელების high-performance serving framework, Python-ში. RadixAttention ტექნოლოგია KV cache-ს ავტომატურად sharing-ს ახდენს prefixes-ს შორის, რაც throughput-ს მნიშვნელოვნად ზრდის batch workloads-ზე. vLLM-ის ალტერნატივა, რომელიც გარკვეულ workload-ებზე უფრო სწრაფია. structured output generation (JSON schema enforcement) ჩაშენებული. UC Berkeley-ს მკვლევარები ნაყარი, Google, Microsoft, xAI-ის infrastructure-ში გამოიყენება.",
+      "starsNumeric": 26000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "FLUX",
+      "url": "https://github.com/black-forest-labs/flux",
+      "stars": "25K",
+      "description": "FLUX — Black Forest Labs-ის FLUX.1 image generation მოდელების official inference repo. Black Forest Labs-ი Stable Diffusion-ის ორიგინალი შემქმნელების მიერ 2024 წელს დაარსდა. **ლიცენზიები**: FLUX.1 [schnell] — Apache 2.0 (სრულად ღია), FLUX.1 [dev] — არაკომერციული ლიცენზიით (research/personal). ასევე სპეციალიზებული ვარიანტები: Fill, Canny, Depth, Redux, Kontext, Krea. flow matching ტექნიკა ჩვეულებრივი diffusion-ის ნაცვლად — უფრო სწრაფი sampling. ComfyUI-სა და Diffusers-ზე მშობლიურად ინტეგრირებული, Replicate-ზე ხელმისაწვდომი. ერთ-ერთი ყველაზე ფართოდ გავრცელებული ღია image generation მოდელი.",
+      "starsNumeric": 25000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Google Workspace CLI",
+      "url": "https://github.com/googleworkspace/cli",
+      "stars": "25K",
+      "description": "Google Workspace CLI — Google-ის ოფიციალური command-line ხელსაწყო Gmail-ის, Drive-ის, Calendar-ის, Sheets-ის, Docs-ის, Chat-ისა და Admin-ისთვის. Rust-ში დაწერილი, Google Discovery Service-ისგან დინამიურად გენერირდება — ნებისმიერ ახალ Workspace API-ს ავტომატურად მხარს უჭერს. ჩაშენებული AI agent skills-ებით AI-ს შეუძლია Workspace-ის ოპერაციების ავტონომიურად შესრულება. 2026 წლის მარტში გამოჩნდა — AI agent workflow automation-ის ახალი სტანდარტი Google ეკოსისტემისთვის.",
+      "starsNumeric": 25000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "toon",
+      "url": "https://github.com/toon-format/toon",
+      "stars": "23K",
+      "description": "TOON (Token-Oriented Object Notation) არის JSON-ის ალტერნატიული სერიალიზაციის ფორმატი, სპეციალურად LLM prompt-ებისთვის ოპტიმიზებული — compact, human-readable და schema-aware. benchmark-ების მიხედვით JSON-ზე 39%-ით ნაკლებ ტოკენს მოიხმარს ერთსა და იმავე მონაცემებისთვის, რაც API ხარჯებს პირდაპირ ამცირებს. სპეციფიკაცია, benchmark-ები და TypeScript SDK ღია კოდით ხელმისაწვდომია. ეს ფრეიმვორკი არ არის — ინფრასტრუქტურის კომპონენტია ვინც LLM-ებს დიდ structured data-ს გადასცემს.",
+      "starsNumeric": 23000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Kronos",
+      "url": "https://github.com/shiyu-coder/Kronos",
+      "stars": "20K",
+      "description": "Kronos არის Python-ის pre-trained foundation model, რომელიც სპეციალურად ფინანსური ბაზრების „ენაზე\" — K-line (კანდლსტიქ) სერიებზე, ფინანსურ ინდიკატორებზე — ნატრენინგია, ჩვეულებრივ ტექსტური corpus-ის ნაცვლად. AAAI 2026-ის კონფერენციაზე მიღებული აკადემიური ნაშრომი მას მხარს უჭერს. ეს არ არის agent framework — ეს დომენ-სპეციფიკური LLM-ის კვლევის ნიმუშია. ფინანსური ML-ის მკვლევარებისთვის და ტრეიდინგ სისტემების ბექ-ენდის ასაშენებლად.",
+      "starsNumeric": 20000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "VoxCPM",
+      "url": "https://github.com/OpenBMB/VoxCPM",
+      "stars": "15K",
+      "description": "VoxCPM2 — tokenizer-free multilingual text-to-speech სისტემა OpenBMB-ისგან (Tsinghua University-ის კვლევითი ჯგუფი). 30 ენაზე მუშაობს language tag-ის გარეშე, 3 წამიანი ნიმუშიდან ხმის კლონირება, 48kHz სტუდიური ხარისხი. 2 მილიარდი პარამეტრი, 8GB VRAM-ზე ეშვება, Apache 2.0 ლიცენზია. Minimax benchmark-ზე 85.4% ხმის მსგავსება. ElevenLabs-ის ღია ალტერნატივა — კომერციული სერვისის გარეშე სტუდიური ხარისხის TTS.",
+      "starsNumeric": 15000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "HunyuanVideo",
+      "url": "https://github.com/Tencent-Hunyuan/HunyuanVideo",
+      "stars": "12K",
+      "description": "HunyuanVideo — Tencent-ის large-scale video generation framework. ტექსტიდან, სურათიდან ან audio prompt-ისგან ვიდეოს გენერაცია. Python-ში დაწერილი, Hugging Face-ზე ხელმისაწვდომი. 13 მილიარდი პარამეტრი, Wan-ის მსგავსი სხვა ღია video gen მოდელებთან კონკურენტული. ლოკალური გაშვება მძლავრ GPU-ს მოითხოვს (80GB VRAM რეკომენდირებულია). ფართო ვიდეო გენერაციული research-ისა და ComfyUI-ს workflow-ებისთვის.",
+      "starsNumeric": 12000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "NotebookLM Python",
+      "url": "https://github.com/teng-lin/notebooklm-py",
+      "stars": "11K",
+      "description": "notebooklm-py — Google NotebookLM-ის არაოფიციალური Python API და agentic skill. Google-ის ოფიციალური library კი არ არის — reverse-engineered Python wrapper, რომელიც NotebookLM-ის ვებ ინტერფეისში მიუწვდომელ ფუნქციებსაც ხსნის. AI podcast-ის გენერაცია, კვლევის ავტომატიზაცია, CLI-ს მხარდაჭერა. Claude Code, Codex, OpenClaw-ში agentic skill-ად გამოიყენება. Python-ში, ლოკალური automation-ისთვის. სტაბილურობა Google-ის API-ს ცვლილებებზეა დამოკიდებული.",
+      "starsNumeric": 11000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Hyperframes",
+      "url": "https://github.com/heygen-com/hyperframes",
+      "stars": "11K",
+      "description": "Hyperframes — HeyGen-ის (AI avatar video-ს წამყვანი კომპანია) TypeScript framework, რომელიც HTML/CSS-ს ვიდეოდ გარდაქმნის. სპეციალურად AI აგენტებისთვის შექმნილი: აგენტი HTML-ს წერს, Hyperframes ვიდეოდ render-ავს — კოდირების ვიდეო pipeline. რეპოში არის [Claude-სპეციფიკური design guide](https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md) — Claude.ai-ში ვიდეო template-ის პირველ draft-ს ქმნი, ZIP-ით ჩამოგაქვს, შემდეგ Claude Code-ი ფინიშავს ანიმაციებს. Remotion-ის კონკურენტი declarative agent-first მიდგომით — Plain HTML + GSAP, React-ის გარეშე. 2026 მარტში გამოვიდა, Apache 2.0.",
+      "starsNumeric": 11000,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "LM Studio",
+      "url": "https://github.com/lmstudio-ai/lms",
+      "stars": "4.7K",
+      "description": "LM Studio CLI — LM Studio-ს ლოკალური AI პლატფორმის command-line interface, TypeScript-ში. LM Studio-ს გრაფიკულ სახელმძღვანელოს ავსებს: სერვერის გაშვება/გაჩერება, მოდელების ჩატვირთვა GPU acceleration-ით, model management, process monitoring ტერმინალიდან. CI/CD pipeline-ებში, automation scripts-ში გამოსადეგია სადაც GUI მიუწვდომელია. Ollama-ს ალტერნატივა მათთვის, ვინც LM Studio-ს ვიზუალური ინტერფეისს ანიჭებს უპირატესობას.",
+      "starsNumeric": 4700,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "RealtimeTTS",
+      "url": "https://github.com/KoljaB/RealtimeTTS",
+      "stars": "3.9K",
+      "description": "RealtimeTTS — Python ბიბლიოთეკა, რომელიც ტექსტს ხმად real-time-ში გარდაქმნის, streaming input-ისთვის ოპტიმიზებული. LLM-ის output-ს stream-ად ღებულობს და პირველ სიტყვებს 2 წამში წარმოაჩენს — სრული response-ის დასრულების გარეშე. Coqui, ElevenLabs, Azure, Piper, Kokoro — მრავალი TTS backend მხარდაჭერილია ერთი API-ით. ხმის კლონირება Coqui backend-ით. Kolja Beigel-ის (KoljaB) independent project, MIT ლიცენზია. სრული voice AI pipeline-ების ასაწყობად.",
+      "starsNumeric": 3900,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "video-use",
+      "url": "https://github.com/browser-use/video-use",
+      "stars": "3.8K",
+      "description": "video-use — Browser Use გუნდის ხელსაწყო ვიდეო მონტაჟისთვის AI კოდინგ აგენტების მეშვეობით. ბუნებრივ ენაზე გაიცი ინსტრუქცია (ფრაგმენტების შეერთება, subtitle-ების დამატება, audio-ს ჩანაცვლება, speed-ის შეცვლა) და AI FFmpeg-ის სკრიპტს ავტომატურად წერს და ახორციელებს. Python-ში, 2026 წლის აპრილში გამოჩნდა. agentic media processing-ის ახალი მიმართულების ადრეული demo — NLE (non-linear editor) UI-ის გარეშე, პროგრამული ვიდეო workflow-ებისთვის.",
+      "starsNumeric": 3800,
+      "categorySlug": "infra",
+      "categoryEmoji": "⚙️",
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+    },
+    {
+      "name": "Build Your Own X",
+      "url": "https://github.com/codecrafters-io/build-your-own-x",
+      "stars": "493K",
+      "description": "Build Your Own X — GitHub-ის ყველაზე ვარსკვლავიანი სასწავლო რეპოზიტორიებს შორის, CodeCrafters-ის მიერ: tutorial-ების კატალოგი, სადაც ტექნოლოგიებს ნულიდან ადგენ. Git, Docker, database, operating system, programming language, LLM, neural network, web browser, game engine — ათასობით ნაბიჯ-ნაბიჯ სახელმძღვანელო კატეგორიებით. Markdown-ში, ენა-ნეიტრალური. CodeCrafters-ის ინტერაქტიული platforma-ს კომპანიური სია. პროგრამირების სიღრმის გაგებისთვის — system-level ცოდნის შეძენის საუკეთესო რესურსი.",
+      "starsNumeric": 493000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Public APIs",
+      "url": "https://github.com/public-apis/public-apis",
+      "stars": "426K",
+      "description": "Public APIs — GitHub-ის ერთ-ერთი ყველაზე ვარსკვლავიანი რეპოზიტორია, ასობით კატეგორიზებული უფასო API-ს კოლექტიური სია. ამინდი, მუსიკა, ფინანსები, რუკები, სპორტი, სახელმწიფო მონაცემები, AI სერვისები — authentication-ის, CORS-ის და ლიცენზიის ინფორმაციით. Python-ში დაწერილი ვალიდაციის სკრიპტებით, community-maintained. AI აგენტის workflow-ების ასაწყობისას — პირველი გაჩერება, სანამ API-ის ძებნას შეუდგები.",
+      "starsNumeric": 426000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "System Prompts Collection",
+      "url": "https://github.com/x1xhlol/system-prompts-and-models-of-ai-tools",
+      "stars": "135K",
+      "description": "System Prompts Collection — 25-ზე მეტი AI ხელსაწყოს leaked და public system prompt-ების კოლექცია: Claude Code, Cursor, Devin AI, v0, Lovable, Replit, Windsurf, Manus, Perplexity, Kiro, Warp, Xcode და სხვა. prompt engineering-ის შეუცვლელი სასწავლო მასალა — ფრონტიერ კომპანიები სისტემურ prompt-ებს რა სტრუქტურით, ენით და ლოგიკით წერენ. AI Agent-ების ასაწყობად, product prompt engineering-ისთვის, ან კონკურენტული ანალიზისთვის. Community-ის მიერ განახლდება.",
+      "starsNumeric": 135000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "LLMs from Scratch",
+      "url": "https://github.com/rasbt/LLMs-from-scratch",
+      "stars": "91K",
+      "description": "LLMs from Scratch — Sebastian Raschka-ს (Lightning AI-ის მკვლევარი) წიგნის \"Build a Large Language Model (From Scratch)\" Jupyter Notebook კოლექცია. ChatGPT-ის მსგავსი LLM PyTorch-ში ნულიდან: attention mechanism, tokenization, pre-training, fine-tuning, RLHF — ყველა ეტაპი კოდით. Manning Publications-ის ბესტსელერი, ღია Jupyter notebooks-ით. AI-ის შიდა მექანიზმის გასაგებად ყველაზე სრული, პრაქტიკული სასწავლო კურსი — კვლევისა და საინჟინრო გაგებისთვის.",
+      "starsNumeric": 91000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "AutoResearch",
+      "url": "https://github.com/karpathy/autoresearch",
+      "stars": "76K",
+      "description": "AutoResearch არის Andrej Karpathy-ს (OpenAI-ის ყოფილი კვლევის ხელმძღვანელი, Tesla AI-ის ყოფილი ხელმძღვანელი) ექსპერიმენტული Python პროექტი, სადაც AI აგენტები nanochat-ის ერთ-GPU-ზე ტრენინგს ავტომატურად წარმართავენ. პროექტი ავლენს „automated ML research\" ცნებას — აგენტები ექსპერიმენტებს ჩაატარებენ, შედეგებს შეაფასებენ და ციკლს ადამიანის ჩარევის გარეშე გაიმეორებენ. Karpathy-ს ავტორიტეტის გამო სწრაფად დაიგროვა 76K ვარსკვლავი, თუმცა ეს კვლევითი/სადემონსტრაციო პროექტია, არა production-ready ფრეიმვორკი. ML კვლევის ავტომატიზაციით დაინტერესებულთათვის საყურადღებო მიმართულებაა.",
+      "starsNumeric": 76000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "DESIGN.md",
+      "url": "https://github.com/google-labs-code/design.md",
+      "stars": "6.3K",
+      "description": "DESIGN.md — Google Labs-ის ოფიციალური ფორმატის სპეციფიკაცია, რომლითაც ბრენდის ვიზუალური იდენტობა (ფერები, ტიპოგრაფია, სპეისინგი, კომპონენტების ქცევა, ინტერაქციების შაბლონები) სტრუქტურირებულად აღუწერ AI coding agent-ებს. DESIGN.md ფაილი პროექტის root-ში ჩასვი და Claude Code-ს, Cursor-ს ან Codex-ს უკვე მუდმივი, თანმიმდევრული გაგება აქვს შენი design system-ის — UI ყოველ ახალ ფიჩერზე ერთ სტილში გენერირდება, stylistic drift-ისა და ჰალუცინაციების გარეშე. TypeScript-ში, Apache 2.0 ლიცენზიით. 2026 წლის 10 აპრილს გამოიცა და 14 დღეში 6,300+ ვარსკვლავი დააგროვა (დღეში ~450 ⭐) — ვირუსული ზრდა Anthropic-ის Agent Skills Spec-ის ანალოგი, მაგრამ design systems-ის დომენში. კომპანიონი `awesome-design-md` (რომელიც ასევე გვაქვს) ამ სპეციფიკაციით შექმნილ 55+ მაგალითს გვაწვდის — ეს მათი ფუნდამენტი სტანდარტია.",
+      "starsNumeric": 6300,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Awesome DESIGN.md",
+      "url": "https://github.com/VoltAgent/awesome-design-md",
+      "stars": "64K",
+      "description": "Awesome DESIGN.md — 55-ზე მეტი Markdown ფაილის კოლექცია, პოპულარური brand design systems-ის (Stripe, Google, Apple, Linear) სტილის მიხედვით შექმნილი. DESIGN.md ფაილი პროექტში ჩასვი და Claude Code-ს, Cursor-ს ან სხვა coding agent-ს უთხარი — UI ავტომატურად შენი brand-ის სტილში გენერირდება. VoltAgent-ის მიერ, 2026 წლის მარტიდან. ვიზუალური კოდ-გენერაციის სამუშაო პროცესებში — ყველაზე სწრაფი გზა brand-consistent UI-სკენ კოდის ხელით წერის გარეშე.",
+      "starsNumeric": 64000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Anthropic Cookbook",
+      "url": "https://github.com/anthropics/anthropic-cookbook",
+      "stars": "41K",
+      "description": "Anthropic Cookbook — Anthropic-ის ოფიციალური Jupyter Notebook კოლექცია Claude API-ის გამოყენების პრაქტიკული მაგალითებით. tool use, prompt caching, multi-agent workflows, vision, PDF processing, computer use, extended thinking, batch API — ყველა ძირითადი Claude-ის შესაძლებლობა კოდური მაგალითებით. Anthropic-ის გუნდი პირდაპირ ინარჩუნებს — ახალი features-ების გამოშვებასთან ერთად ემატება. Claude API-ს პირველად მომხმარებლებისთვის — ოფიციალური დასაწყისი.",
+      "starsNumeric": 41000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Awesome Claude Code",
+      "url": "https://github.com/hesreallyhim/awesome-claude-code",
+      "stars": "40K",
+      "description": "Awesome Claude Code — Claude Code-ის (Anthropic) ecosystem-ის კურირებული სია: skills, hooks, slash-commands, agent orchestrators, applications, plugins. Claude Code-ის მაქსიმალურად ეფექტური გამოყენებისთვის — community-ის საუკეთესო workflow-ები, automation scripts, ინტეგრაციები ერთ ადგილზე. Python-ში, community-maintained. Claude Code-ის ახალი მომხმარებლებისთვის — გამოყენების შაბლონების, advanced workflows-ების სწრაფი შესწავლის პირველი გაჩერება.",
+      "starsNumeric": 40000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Claude × HyperFrames Guide",
+      "url": "https://github.com/heygen-com/hyperframes/blob/main/docs/guides/claude-design-hyperframes.md",
+      "stars": "Guide",
+      "description": "Claude × HyperFrames Guide — HeyGen-ის ოფიციალური სახელმძღვანელო Claude.ai-სა და Claude Code-ის გუნდური workflow-ის შესახებ video template-ების შექმნისთვის. Claude.ai აშენებს პირველ draft-ს (ბრენდი, ლეიაუტი, scenes) HTML/CSS/GSAP-ით — შემდეგ user ZIP-ად ჩამოაქვს და Claude Code-ი polish-ს აკეთებს (timing, easing, mid-scene activity). Banned fonts/pairings სია anti-monoculture-ისთვის, skeleton-ები video type-ის მიხედვით (social reel 9:16, launch teaser 16:9, product explainer, cinematic title), structural lint-ის წესები. Template-first AI design-ის ერთ-ერთი პირველი ოფიციალური workflow დოკუმენტი.",
+      "starsNumeric": null,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "LLM-Maintained Wiki (Karpathy)",
+      "url": "https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f",
+      "stars": "Gist",
+      "description": "Andrej Karpathy-ს (OpenAI-ისა და Tesla-ს ყოფილი AI ხელმძღვანელი) კონცეფტუალური gist — AI ავტომატურად ქმნის და ანახლებს პერსონალურ Markdown wiki-ს ახალი ინფორმაციის მიხედვით. RAG-ის ალტერნატიული მიდგომა: ინფორმაცია არ ინახება vector DB-ში, არამედ LLM თავად გადაწერს, აახლებს და ჯვარედინ მითითებებს ამატებს wiki გვერდებში. კოდი კი არა — განსაზღვრის, ხედვის ნაშრომია, რომელმაც LLM-maintained knowledge bases-ის შესახებ ფართო დისკუსია გამოიწვია.",
+      "starsNumeric": null,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Claude How-To",
+      "url": "https://github.com/luongnv89/claude-howto",
+      "stars": "28K",
+      "description": "Claude How-To — ვიზუალური, მაგალითებზე დაფუძნებული სახელმძღვანელო Claude Code-ისთვის: ძირითადი კონცეფტებიდან advanced agent-ების მშენებლობამდე, copy-paste შაბლონებით. Python-ში, 2025 წელს შექმნილი. Anthropic Cookbook-ისგან განსხვავებით, ნაკლებ ოფიციალური და უფრო community-style — მაგრამ მეტი ready-to-use template-ებით. Claude Code-ის ახალი მომხმარებლებისთვის, ვისაც სწრაფი, პრაქტიკული სახელმძღვანელო სჭირდება.",
+      "starsNumeric": 28000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    },
+    {
+      "name": "Free LLM API Resources",
+      "url": "https://github.com/cheahjs/free-llm-api-resources",
+      "stars": "19K",
+      "description": "Free LLM API Resources — 26-ზე მეტი უფასო LLM inference სერვისის კურირებული სია API-ზე წვდომით: OpenRouter, Google AI Studio, NVIDIA NIM, Mistral, Groq, Cerebras, Together AI და სხვა. ყოველი სერვისისთვის — ხელმისაწვდომი მოდელები, rate limits, registration requirements. Python-ში, cheahjs-ის მიერ, community-ის განახლებებით. prototype-ებისა და სასწავლო პროექტებისთვის, სადაც გადასახადი არ გსურს — ყველაზე სრული სია.",
+      "starsNumeric": 19000,
+      "categorySlug": "resources",
+      "categoryEmoji": "📚",
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+    }
+  ]
+}

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,2672 @@
+{
+  "name": "@aipulsegeorgia/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@aipulsegeorgia/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "aipulsegeorgia-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "tsup": "^8.3.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@aipulsegeorgia/mcp-server",
+  "version": "0.1.0",
+  "description": "MCP server for the AI Pulse Georgia awesome list — query 179+ curated AI repos from inside Claude Code, Cursor, and other MCP-compatible clients.",
+  "type": "module",
+  "bin": {
+    "aipulsegeorgia-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "data",
+    "README.md"
+  ],
+  "scripts": {
+    "build:data": "tsx scripts/build-data.ts",
+    "build": "npm run build:data && tsup src/index.ts --format esm --target node20 --clean --shims",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "claude",
+    "awesome-list",
+    "ai-pulse-georgia"
+  ],
+  "author": "AI Pulse Georgia <hello@aipulsegeorgia.ge>",
+  "license": "MIT",
+  "homepage": "https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia/tree/main/mcp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia.git",
+    "directory": "mcp"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsup": "^8.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/mcp/scripts/build-data.ts
+++ b/mcp/scripts/build-data.ts
@@ -1,0 +1,138 @@
+/**
+ * Parses the root README.md and emits data/repos.json — the canonical
+ * data source for the MCP server. Run on every README change.
+ *
+ * Output: { generated, totalRepos, categories, repos }
+ */
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..", "..");
+const README = resolve(ROOT, "README.md");
+const OUT = resolve(__dirname, "..", "data", "repos.json");
+
+type Category = {
+  slug: string;
+  emoji: string;
+  georgian: string;
+  english: string;
+};
+
+const CATEGORY_MAP: Record<string, Omit<Category, "georgian">> = {
+  "კოდინგ აგენტები": { slug: "coding", emoji: "🤖", english: "Coding Agents" },
+  "Claude Code პლაგინები და უნარები": { slug: "plugins", emoji: "⚡", english: "Claude Code Plugins & Skills" },
+  "MCP ინტეგრაციები": { slug: "mcp", emoji: "🔌", english: "MCP Integrations" },
+  "ვებ სკრეიპინგი და ბრაუზერი": { slug: "scraping", emoji: "🕷️", english: "Web Scraping & Browser" },
+  "AI აგენტების ფრეიმვორკები": { slug: "frameworks", emoji: "🧬", english: "AI Agent Frameworks" },
+  "მზა AI აგენტები ბიზნესისთვის": { slug: "business", emoji: "💼", english: "Ready-Made AI Agents for Business" },
+  "მეხსიერება და RAG": { slug: "memory", emoji: "🧠", english: "Memory & RAG" },
+  "AI ინფრასტრუქტურა და ხელსაწყოები": { slug: "infra", emoji: "⚙️", english: "AI Infrastructure & Tools" },
+  "რესურსები და სასწავლო მასალები": { slug: "resources", emoji: "📚", english: "Resources & Learning" },
+};
+
+type Repo = {
+  name: string;
+  url: string;
+  stars: string;
+  starsNumeric: number | null;
+  description: string;
+  categorySlug: string;
+  categoryEmoji: string;
+  categoryGeorgian: string;
+};
+
+/** "11K" → 11000, "187K" → 187000, "1.5M" → 1500000, "Guide" → null */
+function parseStars(raw: string): number | null {
+  const trimmed = raw.trim();
+  const m = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMkm])?$/);
+  if (!m) return null;
+  const num = Number.parseFloat(m[1]!);
+  const unit = (m[2] ?? "").toLowerCase();
+  if (unit === "k") return Math.round(num * 1_000);
+  if (unit === "m") return Math.round(num * 1_000_000);
+  return Math.round(num);
+}
+
+/** Extract Georgian section heading: "## 🤖 კოდინგ აგენტები" → category */
+function parseHeading(line: string): Category | null {
+  const m = line.match(/^##\s+(\p{Emoji_Presentation}|\p{Extended_Pictographic})\s*️?\s+(.+?)\s*$/u);
+  if (!m) return null;
+  const georgian = m[2]!.trim();
+  const meta = CATEGORY_MAP[georgian];
+  if (!meta) return null;
+  return { ...meta, georgian };
+}
+
+/** Extract repo from a markdown table row: | [name](url) | stars | description | */
+function parseRow(line: string): Pick<Repo, "name" | "url" | "stars" | "description"> | null {
+  if (!line.startsWith("| [")) return null;
+  const cells = line.split(" | ").map((c, i, arr) => {
+    if (i === 0) return c.replace(/^\|\s*/, "");
+    if (i === arr.length - 1) return c.replace(/\s*\|\s*$/, "");
+    return c;
+  });
+  if (cells.length !== 3) return null;
+  const linkMatch = cells[0]!.match(/^\[([^\]]+)\]\(([^)]+)\)\s*$/);
+  if (!linkMatch) return null;
+  return {
+    name: linkMatch[1]!.trim(),
+    url: linkMatch[2]!.trim(),
+    stars: cells[1]!.trim(),
+    description: cells[2]!.trim(),
+  };
+}
+
+function parse(): { repos: Repo[]; categories: Category[] } {
+  const text = readFileSync(README, "utf-8");
+  const lines = text.split("\n");
+  const repos: Repo[] = [];
+  const categories: Category[] = [];
+  const seen = new Set<string>();
+  let current: Category | null = null;
+
+  for (const line of lines) {
+    const heading = parseHeading(line);
+    if (heading) {
+      current = heading;
+      if (!seen.has(heading.slug)) {
+        categories.push(heading);
+        seen.add(heading.slug);
+      }
+      continue;
+    }
+    if (!current) continue;
+    const row = parseRow(line);
+    if (!row) continue;
+    repos.push({
+      ...row,
+      starsNumeric: parseStars(row.stars),
+      categorySlug: current.slug,
+      categoryEmoji: current.emoji,
+      categoryGeorgian: current.georgian,
+    });
+  }
+
+  return { repos, categories };
+}
+
+function main(): void {
+  const { repos, categories } = parse();
+  const output = {
+    generated: new Date().toISOString(),
+    totalRepos: repos.length,
+    categories: categories.map((c) => ({
+      ...c,
+      count: repos.filter((r) => r.categorySlug === c.slug).length,
+    })),
+    repos,
+  };
+  mkdirSync(dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n", "utf-8");
+  // eslint-disable-next-line no-console
+  console.log(`Wrote ${repos.length} repos across ${categories.length} categories → ${OUT}`);
+}
+
+main();

--- a/mcp/src/data.ts
+++ b/mcp/src/data.ts
@@ -1,0 +1,62 @@
+/**
+ * Loads the parsed repo collection from data/repos.json at startup.
+ * Throws if the file is missing — `npm run build:data` must run first.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export type Repo = {
+  name: string;
+  url: string;
+  stars: string;
+  starsNumeric: number | null;
+  description: string;
+  categorySlug: string;
+  categoryEmoji: string;
+  categoryGeorgian: string;
+};
+
+export type Category = {
+  slug: string;
+  emoji: string;
+  georgian: string;
+  english: string;
+  count: number;
+};
+
+export type Collection = {
+  generated: string;
+  totalRepos: number;
+  categories: Category[];
+  repos: Repo[];
+};
+
+function findDataPath(): string {
+  // When bundled to dist/, data sits one directory up from the bundle.
+  // When run via tsx in src/, data sits two directories up.
+  const candidates = [
+    resolve(__dirname, "..", "data", "repos.json"),
+    resolve(__dirname, "..", "..", "data", "repos.json"),
+  ];
+  for (const path of candidates) {
+    try {
+      readFileSync(path, "utf-8");
+      return path;
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(
+    `repos.json not found. Run 'npm run build:data' first. Searched: ${candidates.join(", ")}`,
+  );
+}
+
+export function loadCollection(): Collection {
+  const path = findDataPath();
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw) as Collection;
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * AI Pulse Georgia MCP Server
+ *
+ * Exposes the curated awesome-ai-pulse-georgia repo collection (179+ repos
+ * across 9 categories) as MCP tools. Designed for stdio transport — usable
+ * from Claude Code, Cursor, Codex, and any other MCP-compatible client.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { loadCollection, type Repo } from "./data.js";
+
+const collection = loadCollection();
+
+const server = new McpServer({
+  name: "aipulsegeorgia-mcp",
+  version: "0.1.0",
+});
+
+const categorySlugs = collection.categories.map((c) => c.slug) as [string, ...string[]];
+const CategoryEnum = z.enum(categorySlugs);
+
+/** Strip markdown links from descriptions for cleaner LLM input. */
+function clean(desc: string): string {
+  return desc.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1").replace(/\s+/g, " ").trim();
+}
+
+function summarize(r: Repo): string {
+  const stars = r.starsNumeric !== null ? `${r.stars} ⭐` : r.stars;
+  return `${r.name} (${stars}) — ${r.url}\n  ${clean(r.description)}\n  Category: ${r.categoryEmoji} ${r.categoryGeorgian}`;
+}
+
+function jsonResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function textResult(text: string): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text }] };
+}
+
+// --- Tools ---
+
+server.tool(
+  "list_categories",
+  "List all 9 categories with repo counts. Use this first to understand the collection's structure.",
+  {},
+  async () => jsonResult({
+    totalRepos: collection.totalRepos,
+    categories: collection.categories,
+  }),
+);
+
+server.tool(
+  "list_repos",
+  "List repos, optionally filtered by category and sorted. Returns paginated results.",
+  {
+    category: CategoryEnum.optional().describe("Filter by category slug (see list_categories)"),
+    sortBy: z.enum(["stars", "name"]).default("stars").describe("Sort order; 'stars' returns highest-starred first"),
+    limit: z.number().int().min(1).max(100).default(20),
+    offset: z.number().int().min(0).default(0),
+  },
+  async ({ category, sortBy, limit, offset }) => {
+    let filtered = category
+      ? collection.repos.filter((r) => r.categorySlug === category)
+      : collection.repos;
+
+    filtered = [...filtered].sort((a, b) => {
+      if (sortBy === "name") return a.name.localeCompare(b.name);
+      return (b.starsNumeric ?? -1) - (a.starsNumeric ?? -1);
+    });
+
+    const page = filtered.slice(offset, offset + limit);
+    return jsonResult({
+      total: filtered.length,
+      offset,
+      limit,
+      hasMore: offset + limit < filtered.length,
+      repos: page.map((r) => ({
+        name: r.name,
+        url: r.url,
+        stars: r.stars,
+        starsNumeric: r.starsNumeric,
+        category: r.categorySlug,
+        description: clean(r.description),
+      })),
+    });
+  },
+);
+
+server.tool(
+  "search_repos",
+  "Full-text search across name and description. Case-insensitive. Use for queries like 'free claude code', 'browser automation', 'rag'.",
+  {
+    query: z.string().min(2).describe("Search query — at least 2 characters"),
+    category: CategoryEnum.optional().describe("Optionally narrow to a single category"),
+    limit: z.number().int().min(1).max(50).default(10),
+  },
+  async ({ query, category, limit }) => {
+    const q = query.toLowerCase();
+    const tokens = q.split(/\s+/).filter(Boolean);
+
+    const scored = collection.repos
+      .filter((r) => !category || r.categorySlug === category)
+      .map((r) => {
+        const haystack = `${r.name} ${r.description}`.toLowerCase();
+        const score = tokens.reduce((acc, t) => acc + (haystack.includes(t) ? 1 : 0), 0);
+        const nameMatch = r.name.toLowerCase().includes(q) ? 5 : 0;
+        return { repo: r, score: score + nameMatch };
+      })
+      .filter((s) => s.score > 0)
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return (b.repo.starsNumeric ?? -1) - (a.repo.starsNumeric ?? -1);
+      })
+      .slice(0, limit);
+
+    return jsonResult({
+      query,
+      matched: scored.length,
+      repos: scored.map((s) => ({
+        name: s.repo.name,
+        url: s.repo.url,
+        stars: s.repo.stars,
+        category: s.repo.categorySlug,
+        score: s.score,
+        description: clean(s.repo.description),
+      })),
+    });
+  },
+);
+
+server.tool(
+  "get_repo",
+  "Get full details for a single repo by name (case-insensitive, supports partial match).",
+  {
+    name: z.string().min(2).describe("Repo name, e.g. 'Claude Code', 'free-claude-code', 'aider'"),
+  },
+  async ({ name }) => {
+    const q = name.toLowerCase();
+    const exact = collection.repos.find((r) => r.name.toLowerCase() === q);
+    const partial = exact ?? collection.repos.find((r) => r.name.toLowerCase().includes(q));
+    if (!partial) {
+      return textResult(`No repo found matching '${name}'. Try search_repos for fuzzy matching.`);
+    }
+    return textResult(summarize(partial));
+  },
+);
+
+server.tool(
+  "stats",
+  "Collection-level stats: total count, top repos by stars, last generated time.",
+  {},
+  async () => {
+    const top = [...collection.repos]
+      .filter((r) => r.starsNumeric !== null)
+      .sort((a, b) => (b.starsNumeric ?? 0) - (a.starsNumeric ?? 0))
+      .slice(0, 10)
+      .map((r) => ({ name: r.name, stars: r.stars, url: r.url, category: r.categorySlug }));
+    return jsonResult({
+      totalRepos: collection.totalRepos,
+      categories: collection.categories.length,
+      generated: collection.generated,
+      top10ByStars: top,
+    });
+  },
+);
+
+// --- Boot ---
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+// Note: do NOT console.log on stdout — that channel is the MCP transport.
+// Stderr is fine for diagnostics if needed.

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": false,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Adds an **MCP (Model Context Protocol) server** that exposes the awesome-ai-pulse-georgia collection (179 repos, 9 categories) as queryable tools — usable from Claude Code, Cursor, Codex, Claude.ai, and any other MCP-compatible client.

Instead of opening GitHub and scrolling through the README, users can ask their AI assistant:

- *"What's a good free Claude Code alternative?"* → returns `free-claude-code`, `Claw Code`, `OpenClaude`
- *"Show me the top 5 RAG repos in this collection."* → ranked by stars within the `memory` category
- *"Find browser automation tools."* → searches across name + description

## Architecture

- **`mcp/scripts/build-data.ts`** — parses root `README.md` into `data/repos.json` (single source of truth)
- **`mcp/src/index.ts`** — MCP server using `@modelcontextprotocol/sdk@1.29`, stdio transport
- **`mcp/data/repos.json`** — pre-built snapshot (committed) so `npx` users don't need to rebuild
- **TypeScript + ESM**, Node 20+, 5.75 KB compiled bundle

## Tools exposed

| Tool | Purpose |
|------|---------|
| `list_categories` | All 9 categories with repo counts |
| `list_repos` | Browse by category, sort by stars/name, paginate |
| `search_repos` | Full-text search across name + description |
| `get_repo` | Full details for one repo by name |
| `stats` | Collection stats + top 10 by stars |

## Install (after merge + npm publish)

```json
{
  "mcpServers": {
    "aipulsegeorgia": {
      "command": "npx",
      "args": ["-y", "@aipulsegeorgia/mcp-server"]
    }
  }
}
```

## Test plan

- [x] `npm run build:data` — parses 179 repos × 9 categories from README
- [x] `npm run build` — compiles to dist/index.js (5.75 KB ESM)
- [x] Server boots and responds to `initialize` handshake
- [x] `tools/list` returns all 5 tools with correct schemas
- [x] `search_repos({query:"claude code free"})` ranks `free-claude-code` #1 (score 3)
- [x] `stats` returns top-10-by-stars, categories=9, totalRepos=179
- [ ] User merges → publish to npm under `@aipulsegeorgia/mcp-server`

## Why this matters

GitHub README is great for findability via search engines, but in 2026 the highest-leverage discovery surface for AI tools is **inside the IDE** — where developers actually work. Smithery.ai, Awesome MCP Servers, and similar lists exploded in 2025-2026 because MCP turned curated collections into IDE-native superpowers. This PR makes AI Pulse Georgia's collection one of the first Georgian-curated catalogs to ship as an MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)