### PR TITLE
feat(mcp): full distribution pipeline — npm publish, README integration, Smithery, CI

### DIFF
--- a/.github/workflows/mcp-data-sync.yml
+++ b/.github/workflows/mcp-data-sync.yml
@@ -1,0 +1,68 @@
+name: MCP data sync
+
+# Auto-rebuild mcp/data/repos.json whenever README.md or the parser changes.
+# If the parsed data differs from the committed snapshot, bump the patch
+# version and commit both back to main. The version bump triggers
+# mcp-publish.yml which publishes to npm.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'README.md'
+      - 'mcp/scripts/build-data.ts'
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'mcp/package-lock.json'
+
+      - name: Install
+        working-directory: mcp
+        run: npm ci
+
+      - name: Rebuild data snapshot
+        working-directory: mcp
+        run: npm run build:data
+
+      - name: Detect changes
+        id: detect
+        run: |
+          if git diff --quiet -- mcp/data/repos.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No data changes — nothing to publish."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Data changed — will bump patch version and commit."
+          fi
+
+      - name: Bump patch version
+        if: steps.detect.outputs.changed == 'true'
+        working-directory: mcp
+        run: npm version patch --no-git-tag-version
+
+      - name: Commit and push
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add mcp/data/repos.json mcp/package.json mcp/package-lock.json
+          git commit -m "chore(mcp): sync data + bump patch version [skip ci]"
+          git push

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,77 @@
+name: MCP npm publish
+
+# Publish @aipulsegeorgia/mcp-server to npm whenever mcp/package.json is
+# updated on main. Idempotent — checks if the version already exists on
+# npm and skips re-publish when matched. Requires repository secret NPM_TOKEN.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp/package.json'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: 'mcp/package-lock.json'
+
+      - name: Install
+        working-directory: mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: mcp
+        run: npm run build
+
+      - name: Smoke test
+        working-directory: mcp
+        run: npm run smoke
+
+      - name: Read version
+        id: pkg
+        working-directory: mcp
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Check if already published
+        id: check
+        run: |
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} already on npm — skip."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish
+        if: steps.check.outputs.exists == 'false'
+        working-directory: mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "## MCP publish run" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Package: \`${{ steps.pkg.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: \`${{ steps.pkg.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Already published: \`${{ steps.check.outputs.exists }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,27 @@
 
 ---
 
+## ⚡ გამოიყენე Claude Code-ში / Cursor-ში — MCP Server-ით
+
+ეს მთელი კოლექცია ხელმისაწვდომია **MCP server-ად** — Claude Code-ის, Cursor-ის, Codex-ის ან ნებისმიერი MCP-თავსებადი client-ის შიგნიდან 179 რეპოს ეძებ ერთი ბრძანებით. ნაცვლად იმისა, რომ GitHub-ი გახსნა და README-ი დააქოქო, AI ასისტენტს ჰკითხე *"აი Pulse-ის კოლექციაში რა არის საუკეთესო RAG-ისთვის?"* — სწორ რეპოს ქართული აღწერით დაგიბრუნებს.
+
+**Install** — `~/.claude/claude_desktop_config.json` ან Cursor MCP settings-ში:
+
+```json
+{
+  "mcpServers": {
+    "aipulsegeorgia": {
+      "command": "npx",
+      "args": ["-y", "@aipulsegeorgia/mcp-server"]
+    }
+  }
+}
+```
+
+> *Available as an MCP server — query 179 curated AI repos directly from Claude Code, Cursor, or any MCP client.* Full docs: [`mcp/README.md`](./mcp/README.md) · Source: [`mcp/`](./mcp/)
+
+---
+
 ## 🤖 კოდინგ აგენტები
 
 > **Coding Agents & CLI IDEs** — დამოუკიდებელი AI კოდის წერის ხელსაწყოები ტერმინალში და რედაქტორში. თუ პროგრამისტი ხარ და გინდა AI-მ დაგეხმაროს კოდის წერაში, ტესტირებაში ან გამართვაში — ეს სექცია შენთვისაა.

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AI Pulse Georgia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mcp/PUBLISHING.md
+++ b/mcp/PUBLISHING.md
@@ -1,0 +1,110 @@
+# Publishing checklist
+
+Three one-time manual steps to take the MCP server from "merged to main" to "globally installable via `npx`". After this, every README update auto-publishes a patch version through GitHub Actions.
+
+---
+
+## 1. Create your npm account (one-time, ~3 minutes)
+
+Run this in your terminal — opens a browser for login:
+
+```bash
+npm adduser
+```
+
+You'll be prompted for username, email, and password (or you can sign in with GitHub on the browser page). After it succeeds, verify:
+
+```bash
+npm whoami
+```
+
+Should print your username. If not, repeat `npm adduser`.
+
+---
+
+## 2. Publish the first version manually (one-time, ~2 minutes)
+
+From the repo root:
+
+```bash
+cd mcp
+npm install
+npm run build
+npm publish --access public
+```
+
+The `--access public` flag is required for scoped packages on the free plan. `npm publish` will:
+
+1. Run `prepublishOnly` (build + smoke test)
+2. Pack `dist/`, `data/`, `README.md`, `LICENSE` into a tarball
+3. Upload to npm under `@aipulsegeorgia/mcp-server`
+4. Create the `@aipulsegeorgia` scope under your account automatically (first publish)
+
+Verify it worked from any other directory:
+
+```bash
+npx -y @aipulsegeorgia/mcp-server < /dev/null
+```
+
+This boots the server briefly. You should see no errors. (The `< /dev/null` closes stdin so the server exits cleanly.)
+
+---
+
+## 3. Add NPM_TOKEN secret to GitHub (one-time, ~2 minutes)
+
+The `mcp-publish.yml` GitHub Action needs an npm access token to auto-publish on README updates.
+
+**Create the token:**
+
+1. Go to https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+2. Click **Generate New Token** → **Granular Access Token**
+3. Name: `awesome-ai-pulse-georgia-publish`
+4. Expiration: 1 year (recommended)
+5. Packages: select `@aipulsegeorgia/mcp-server` only (or whole `@aipulsegeorgia` scope)
+6. Permissions: **Read and write**
+7. Copy the token (starts with `npm_...`) — you won't see it again
+
+**Add it to GitHub:**
+
+1. Go to https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia/settings/secrets/actions
+2. Click **New repository secret**
+3. Name: `NPM_TOKEN`
+4. Value: paste the npm token
+5. **Add secret**
+
+---
+
+## What happens after these 3 steps
+
+From now on, every time you update `README.md` on `main` (add a repo, refresh stars, etc.):
+
+1. **`mcp-data-sync.yml`** runs → re-parses README → if `mcp/data/repos.json` differs, bumps patch version (e.g., `0.1.1` → `0.1.2`) and commits both back
+2. **`mcp-publish.yml`** triggers on the version bump → builds, runs smoke test, publishes new version to npm
+3. Within ~2 minutes, `npx @aipulsegeorgia/mcp-server` serves the updated catalog
+
+Manual `src/` changes still need a manual `npm version minor && git push` to flow.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `npm publish` fails with `403 Forbidden` | Re-run `npm adduser`. Token may have expired. |
+| `npm publish` fails with `402 Payment Required` | You forgot `--access public` for the scoped package. |
+| GitHub Action fails: `npm error 401 Unauthorized` | `NPM_TOKEN` secret is missing or expired. Re-create per Step 3. |
+| `npm view` says scope is taken | Someone else owns `@aipulsegeorgia` — fall back to `aipulsegeorgia-mcp` (unscoped). Update `name` in package.json. |
+| Action loops infinitely | The `[skip ci]` guard should prevent this. If it triggers, manually disable the workflow and check that the auto-commit message contains `[skip ci]`. |
+
+---
+
+## Smithery.ai listing (after first publish)
+
+Once `npm view @aipulsegeorgia/mcp-server` returns metadata:
+
+1. Go to https://smithery.ai/new
+2. Enter the GitHub repo URL: `https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia`
+3. Smithery auto-detects `mcp/smithery.yaml` and creates the listing
+4. Review takes 24-48 hours typically
+
+After approval, the package appears in Smithery's marketplace at `https://smithery.ai/server/@aipulsegeorgia/mcp-server`.

--- a/mcp/data/repos.json
+++ b/mcp/data/repos.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-26T17:35:38.288Z",
+  "generated": "2026-04-26T18:17:12.175Z",
   "totalRepos": 179,
   "categories": [
     {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -9,14 +9,23 @@
   "files": [
     "dist",
     "data",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build:data": "tsx scripts/build-data.ts",
     "build": "npm run build:data && tsup src/index.ts --format esm --target node20 --clean --shims",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "prepublishOnly": "npm run build"
+    "smoke": "tsx scripts/smoke-test.ts",
+    "prepublishOnly": "npm run build && npm run smoke"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "bugs": {
+    "url": "https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia/issues"
   },
   "engines": {
     "node": ">=20"

--- a/mcp/scripts/smoke-test.ts
+++ b/mcp/scripts/smoke-test.ts
@@ -1,0 +1,136 @@
+/**
+ * Smoke test — boots the compiled MCP server, exchanges an initialize handshake,
+ * lists tools, and exercises one tool call. Exits 0 on success, 1 on failure.
+ *
+ * Used both locally (`npm run smoke`) and in CI before publish (`prepublishOnly`).
+ */
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const BUNDLE = resolve(__dirname, "..", "dist", "index.js");
+
+if (!existsSync(BUNDLE)) {
+  console.error(`✗ Bundle not found: ${BUNDLE}\n  Run 'npm run build' first.`);
+  process.exit(1);
+}
+
+type JsonRpc = {
+  jsonrpc: "2.0";
+  id?: number;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: unknown;
+};
+
+const messages: JsonRpc[] = [
+  {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "smoke-test", version: "1.0" },
+    },
+  },
+  { jsonrpc: "2.0", method: "notifications/initialized" },
+  { jsonrpc: "2.0", id: 2, method: "tools/list" },
+  {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "stats", arguments: {} },
+  },
+  {
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "search_repos", arguments: { query: "claude", limit: 1 } },
+  },
+];
+
+function expect(condition: boolean, label: string): void {
+  if (condition) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    console.error(`  ✗ ${label}`);
+    process.exitCode = 1;
+  }
+}
+
+async function run(): Promise<void> {
+  console.log(`Smoke testing ${BUNDLE}\n`);
+  const proc = spawn("node", [BUNDLE], { stdio: ["pipe", "pipe", "pipe"] });
+  const responses: JsonRpc[] = [];
+  let buffer = "";
+
+  proc.stdout.on("data", (chunk: Buffer) => {
+    buffer += chunk.toString("utf-8");
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        responses.push(JSON.parse(trimmed));
+      } catch {
+        // skip non-JSON noise
+      }
+    }
+  });
+
+  proc.stderr.on("data", (chunk: Buffer) => {
+    process.stderr.write(`[server stderr] ${chunk.toString("utf-8")}`);
+  });
+
+  for (const msg of messages) {
+    proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  // Allow time for all responses
+  await new Promise((r) => setTimeout(r, 1500));
+  proc.kill();
+  await new Promise((r) => proc.once("exit", r));
+
+  // --- Assertions ---
+  const init = responses.find((r) => r.id === 1);
+  expect(init !== undefined, "initialize response received");
+  expect(
+    typeof (init?.result as { serverInfo?: { name: string } } | undefined)?.serverInfo?.name === "string",
+    "server reports its name",
+  );
+
+  const tools = responses.find((r) => r.id === 2);
+  const toolList = (tools?.result as { tools?: Array<{ name: string }> } | undefined)?.tools ?? [];
+  expect(toolList.length === 5, `5 tools registered (got ${toolList.length})`);
+  const expected = ["list_categories", "list_repos", "search_repos", "get_repo", "stats"];
+  for (const name of expected) {
+    expect(toolList.some((t) => t.name === name), `tool '${name}' is registered`);
+  }
+
+  const stats = responses.find((r) => r.id === 3);
+  const statsContent = (stats?.result as { content?: Array<{ text: string }> } | undefined)?.content?.[0]?.text;
+  const statsParsed = statsContent ? (JSON.parse(statsContent) as { totalRepos: number }) : null;
+  expect(statsParsed !== null && statsParsed.totalRepos > 0, `stats returns totalRepos > 0 (got ${statsParsed?.totalRepos})`);
+
+  const search = responses.find((r) => r.id === 4);
+  const searchContent = (search?.result as { content?: Array<{ text: string }> } | undefined)?.content?.[0]?.text;
+  const searchParsed = searchContent ? (JSON.parse(searchContent) as { matched: number }) : null;
+  expect(searchParsed !== null && searchParsed.matched > 0, `search 'claude' returns matches (got ${searchParsed?.matched})`);
+
+  if (process.exitCode === 1) {
+    console.error("\n✗ Smoke test FAILED");
+    process.exit(1);
+  }
+  console.log("\n✓ All smoke checks passed");
+}
+
+run().catch((err: unknown) => {
+  console.error("Smoke test crashed:", err);
+  process.exit(1);
+});

--- a/mcp/smithery.yaml
+++ b/mcp/smithery.yaml
@@ -1,0 +1,35 @@
+# Smithery.ai registry configuration
+# https://smithery.ai/docs/config
+
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required: []
+    properties: {}
+    additionalProperties: false
+  commandFunction: |-
+    (config) => ({
+      command: "npx",
+      args: ["-y", "@aipulsegeorgia/mcp-server"]
+    })
+
+# Display metadata for the Smithery marketplace listing
+displayName: "AI Pulse Georgia"
+description: "Query 179+ curated AI repos (Claude Code plugins, agents, MCP integrations, RAG, frameworks) from inside Claude Code, Cursor, or any MCP client. Maintained by AI Pulse Georgia 🇬🇪."
+icon: "https://raw.githubusercontent.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia/main/assets/banner.svg"
+homepage: "https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia"
+license: "MIT"
+tags:
+  - awesome-list
+  - ai-tools
+  - claude
+  - cursor
+  - directory
+  - search
+
+exampleQuestions:
+  - "What's a good free Claude Code alternative?"
+  - "Show me the top 5 RAG repos in this collection."
+  - "Find browser automation tools."
+  - "List all MCP servers in the AI Pulse Georgia catalog."


### PR DESCRIPTION
## Summary

Comprehensive distribution pipeline for the MCP server. After this PR + 3 one-time manual steps from the maintainer, the AI Pulse Georgia MCP server is globally installable via `npx -y @aipulsegeorgia/mcp-server` and stays in sync with the README forever.

## Four distribution tracks (A, B, C, D from /ultra-think)

### A — npm publish ready
- `mcp/package.json` polished: `publishConfig.access=public`, `files` allowlist, smoke check on `prepublishOnly`
- `mcp/LICENSE` (MIT) added — required for npm publish
- `npm pack --dry-run` verified: **48.2 kB tarball, 5 files** (LICENSE, README, data, dist, package.json)
- Source files (`src/`, `scripts/`, `tsconfig.json`) correctly excluded from publish

### B — Main README integration
- New section above first category: bilingual MCP callout (Georgian primary, English secondary)
- Install JSON for Claude Code / Cursor copy-pasteable
- Links to `mcp/README.md` for full docs

### C — Smithery.ai marketplace listing
- `mcp/smithery.yaml` with stdio `commandFunction`, marketplace metadata, example questions
- Submission instructions in `mcp/PUBLISHING.md`

### D — GitHub Actions auto-publish
- `mcp-data-sync.yml`: on `README.md` push → rebuild `data/repos.json` → if changed, patch-bump version + commit `[skip ci]`
- `mcp-publish.yml`: on `mcp/package.json` push → build → smoke test → publish to npm (idempotent — skips if version already published)

## Smoke test (new — `mcp/scripts/smoke-test.ts`)

11 assertions, all passing locally:

```
✓ initialize response received
✓ server reports its name
✓ 5 tools registered (got 5)
✓ tool 'list_categories' is registered
✓ tool 'list_repos' is registered
✓ tool 'search_repos' is registered
✓ tool 'get_repo' is registered
✓ tool 'stats' is registered
✓ stats returns totalRepos > 0 (got 179)
✓ search 'claude' returns matches (got 1)
✓ All smoke checks passed
```

Wired into `prepublishOnly` so npm refuses to publish a broken build.

## Pre-flight verified

| Check | Result |
|---|---|
| npm scope `@aipulsegeorgia/mcp-server` available | ✅ 404 (free) |
| Fallback `aipulsegeorgia-mcp` available | ✅ 404 (free) |
| Path resolution from arbitrary cwd | ✅ `findDataPath()` finds bundle-relative data |
| `npm pack` content correctness | ✅ 5 files, 48.2 kB |
| Smoke test with real bundle | ✅ 11/11 assertions pass |

## What user needs to do (one-time, ~7 minutes)

Full step-by-step in [`mcp/PUBLISHING.md`](./mcp/PUBLISHING.md). Summary:

1. `npm adduser` — create npm account (browser flow)
2. `cd mcp && npm publish --access public` — first manual publish
3. Add `NPM_TOKEN` secret on GitHub → enables auto-publish workflow

After that, every README repo addition triggers auto-rebuild + auto-publish in CI.

## Risks identified and mitigated

- **Infinite Action loop** → `[skip ci]` in commit message + `paths` filter on triggers
- **Re-publish on already-existing version** → idempotent check via `npm view` before publish
- **Action fails silently** → `id-token: write` permission set, smoke test gates publish
- **NPM_TOKEN missing** → publish skips (workflow fails clearly with 401, troubleshooting in PUBLISHING.md)

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run smoke` — 11/11 assertions pass
- [x] `npm pack --dry-run` — clean tarball, no leaked source
- [x] Server boots from arbitrary cwd
- [x] Bilingual README callout renders correctly
- [ ] User completes 3 manual steps in `mcp/PUBLISHING.md`
- [ ] First `npm publish` succeeds
- [ ] Smithery listing approved (24-48h wait expected)
- [ ] Test next README change triggers full auto-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /ultra-think