### PR TITLE
feat(mcp): v0.2.0 — bilingual descriptions (English + Georgian)

### DIFF
--- a/.github/workflows/mcp-data-sync.yml
+++ b/.github/workflows/mcp-data-sync.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Rebuild data snapshot
         working-directory: mcp
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build:data
 
       - name: Detect changes

--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build
         working-directory: mcp
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build
 
       - name: Smoke test

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,7 +8,7 @@ Instead of opening GitHub and scrolling through a README, ask your AI assistant:
 > "Show me the top 5 RAG repos in this collection."
 > "Find browser automation tools written in TypeScript."
 
-The MCP server returns curated results from AI Pulse Georgia's hand-maintained list — every repo is vetted, categorized, and described in Georgian + English.
+The MCP server returns curated results from AI Pulse Georgia's hand-maintained list — every repo is vetted, categorized, and described in **both English and Georgian**. Pass `lang: "en"` (default), `"ka"`, or `"both"` to any tool.
 
 ---
 
@@ -67,10 +67,12 @@ Then point your client at the absolute path of `dist/index.js` instead of `npx`.
 | Tool | Purpose | Example call |
 |------|---------|--------------|
 | `list_categories` | Show all 9 categories with repo counts | — |
-| `list_repos` | Browse by category, sort by stars or name, paginate | `{"category":"coding","limit":10}` |
-| `search_repos` | Full-text search across name + description | `{"query":"browser automation"}` |
-| `get_repo` | Fetch full details for a single repo | `{"name":"free-claude-code"}` |
-| `stats` | Total count + top 10 by stars | — |
+| `list_repos` | Browse by category, sort by stars or name, paginate | `{"category":"coding","limit":10,"lang":"en"}` |
+| `search_repos` | Full-text search across name + descriptions (EN+KA) | `{"query":"browser automation","lang":"both"}` |
+| `get_repo` | Fetch full details for a single repo | `{"name":"free-claude-code","lang":"en"}` |
+| `stats` | Total count, top 10 by stars, English-coverage rate | — |
+
+All tools accept `lang: "en" | "ka" | "both"` (default `"en"`). English descriptions come from each repo's GitHub `description` field; Georgian descriptions are AI Pulse Georgia's editorial reviews from the awesome-list README.
 
 ### Categories
 

--- a/mcp/data/github-cache.json
+++ b/mcp/data/github-cache.json
@@ -1,0 +1,710 @@
+{
+  "ultraworkers/claw-code": {
+    "description": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https://discord.gg/5TUQKqFWd Built in Rust using oh-my-codex.",
+    "fetchedAt": "2026-04-26T20:46:49.516Z"
+  },
+  "anomalyco/opencode": {
+    "description": "The open source coding agent.",
+    "fetchedAt": "2026-04-26T20:46:50.008Z"
+  },
+  "google-gemini/gemini-cli": {
+    "description": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
+    "fetchedAt": "2026-04-26T20:46:50.471Z"
+  },
+  "openai/codex": {
+    "description": "Lightweight coding agent that runs in your terminal",
+    "fetchedAt": "2026-04-26T20:46:50.925Z"
+  },
+  "All-Hands-AI/OpenHands": {
+    "description": "🙌 OpenHands: AI-Driven Development",
+    "fetchedAt": "2026-04-26T20:46:51.790Z"
+  },
+  "cline/cline": {
+    "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, executing commands, using the browser, and more with your permission every step of the way.",
+    "fetchedAt": "2026-04-26T20:46:52.433Z"
+  },
+  "code-yeongyu/oh-my-openagent": {
+    "description": "omo; the best agent harness - previously oh-my-opencode",
+    "fetchedAt": "2026-04-26T20:46:52.801Z"
+  },
+  "Aider-AI/aider": {
+    "description": "aider is AI pair programming in your terminal",
+    "fetchedAt": "2026-04-26T20:46:53.279Z"
+  },
+  "aaif-goose/goose": {
+    "description": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM",
+    "fetchedAt": "2026-04-26T20:46:53.735Z"
+  },
+  "TabbyML/tabby": {
+    "description": "Self-hosted AI coding assistant",
+    "fetchedAt": "2026-04-26T20:46:54.184Z"
+  },
+  "continuedev/continue": {
+    "description": "⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI",
+    "fetchedAt": "2026-04-26T20:46:54.844Z"
+  },
+  "voideditor/void": {
+    "description": null,
+    "fetchedAt": "2026-04-26T20:46:55.307Z"
+  },
+  "abhigyanpatwari/GitNexus": {
+    "description": "GitNexus: The Zero-Server Code Intelligence Engine -       GitNexus is a client-side knowledge graph creator that runs entirely in your browser. Drop in a GitHub repo or ZIP file, and get an interactive knowledge graph wit a built in Graph RAG Agent. Perfect for code exploration",
+    "fetchedAt": "2026-04-26T20:46:55.700Z"
+  },
+  "eyaltoledano/claude-task-master": {
+    "description": "An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others.",
+    "fetchedAt": "2026-04-26T20:46:56.284Z"
+  },
+  "Gitlawb/openclaude": {
+    "description": "Open Claude Is Open-source coding-agent CLI for OpenAI, Gemini, DeepSeek, Ollama, Codex, GitHub Models, and 200+ models via OpenAI-compatible APIs.",
+    "fetchedAt": "2026-04-26T20:46:56.736Z"
+  },
+  "QwenLM/qwen-code": {
+    "description": "An open-source AI agent that lives in your terminal.",
+    "fetchedAt": "2026-04-26T20:46:57.162Z"
+  },
+  "RooCodeInc/Roo-Code": {
+    "description": "Roo Code gives you a whole dev team of AI agents in your code editor.",
+    "fetchedAt": "2026-04-26T20:46:57.625Z"
+  },
+  "kilo-org/kilocode": {
+    "description": "Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.",
+    "fetchedAt": "2026-04-26T20:46:58.102Z"
+  },
+  "openai/codex-plugin-cc": {
+    "description": "Use Codex from Claude Code to review code or delegate tasks.",
+    "fetchedAt": "2026-04-26T20:46:58.751Z"
+  },
+  "manaflow-ai/cmux": {
+    "description": "Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents",
+    "fetchedAt": "2026-04-26T20:46:59.272Z"
+  },
+  "Alishahryar1/free-claude-code": {
+    "description": "Use claude-code for free in the terminal, VSCode extension or via discord like openclaw",
+    "fetchedAt": "2026-04-26T20:46:59.690Z"
+  },
+  "huggingface/ml-intern": {
+    "description": "🤗 ml-intern: an open-source ML engineer that reads papers, trains models, and ships ML models",
+    "fetchedAt": "2026-04-26T20:47:00.159Z"
+  },
+  "vercel-labs/open-agents": {
+    "description": "An open source template for building cloud agents.",
+    "fetchedAt": "2026-04-26T20:47:00.667Z"
+  },
+  "obra/superpowers": {
+    "description": "An agentic skills framework & software development methodology that works.",
+    "fetchedAt": "2026-04-26T20:47:01.072Z"
+  },
+  "affaan-m/everything-claude-code": {
+    "description": "The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond.",
+    "fetchedAt": "2026-04-26T20:47:01.475Z"
+  },
+  "github/spec-kit": {
+    "description": "💫 Toolkit to help you get started with Spec-Driven Development",
+    "fetchedAt": "2026-04-26T20:47:01.955Z"
+  },
+  "forrestchang/andrej-karpathy-skills": {
+    "description": "A single CLAUDE.md file to improve Claude Code behavior, derived from Andrej Karpathy's observations on LLM coding pitfalls.",
+    "fetchedAt": "2026-04-26T20:47:02.407Z"
+  },
+  "nextlevelbuilder/ui-ux-pro-max-skill": {
+    "description": "An AI SKILL that provide design intelligence for building professional UI/UX multiple platforms",
+    "fetchedAt": "2026-04-26T20:47:02.825Z"
+  },
+  "thedotmack/claude-mem": {
+    "description": "A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude's agent-sdk), and injects relevant context back into future sessions.",
+    "fetchedAt": "2026-04-26T20:47:03.222Z"
+  },
+  "gsd-build/get-shit-done": {
+    "description": "A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code by TÂCHES.",
+    "fetchedAt": "2026-04-26T20:47:03.684Z"
+  },
+  "JuliusBrussee/caveman": {
+    "description": "🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman",
+    "fetchedAt": "2026-04-26T20:47:04.067Z"
+  },
+  "santifer/career-ops": {
+    "description": "AI-powered job search system built on Claude Code. 14 skill modes, Go dashboard, PDF generation, batch processing.",
+    "fetchedAt": "2026-04-26T20:47:04.476Z"
+  },
+  "safishamsi/graphify": {
+    "description": "AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, OpenClaw, Factory Droid, Trae, Google Antigravity). Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph",
+    "fetchedAt": "2026-04-26T20:47:04.876Z"
+  },
+  "ruvnet/claude-flow": {
+    "description": "🌊 The leading agent orchestration platform for Claude. Deploy intelligent multi-agent swarms, coordinate autonomous workflows, and build conversational AI systems. Features    enterprise-grade architecture, distributed swarm intelligence, RAG integration, and native Claude Code / Codex Integration",
+    "fetchedAt": "2026-04-26T20:47:07.326Z"
+  },
+  "yeachan-heo/oh-my-claudecode": {
+    "description": "Teams-first Multi-agent orchestration for Claude Code",
+    "fetchedAt": "2026-04-26T20:47:07.710Z"
+  },
+  "kepano/obsidian-skills": {
+    "description": "Agent skills for Obsidian. Teach your agent to use Markdown, Bases, JSON Canvas, and use the CLI.",
+    "fetchedAt": "2026-04-26T20:47:08.094Z"
+  },
+  "mvanhorn/last30days-skill": {
+    "description": "AI agent skill that researches any topic across Reddit, X, YouTube, HN, Polymarket, and the web - then synthesizes a grounded summary",
+    "fetchedAt": "2026-04-26T20:47:08.487Z"
+  },
+  "addyosmani/agent-skills": {
+    "description": "Production-grade engineering skills for AI coding agents.",
+    "fetchedAt": "2026-04-26T20:47:08.875Z"
+  },
+  "anthropics/claude-plugins-official": {
+    "description": "Official, Anthropic-managed directory of high quality Claude Code Plugins.",
+    "fetchedAt": "2026-04-26T20:47:09.559Z"
+  },
+  "agentskills/agentskills": {
+    "description": "Specification and documentation for Agent Skills",
+    "fetchedAt": "2026-04-26T20:47:09.990Z"
+  },
+  "Donchitos/Claude-Code-Game-Studios": {
+    "description": "Turn Claude Code into a full game dev studio — 49 AI agents, 72 workflow skills, and a complete coordination system mirroring real studio hierarchy.",
+    "fetchedAt": "2026-04-26T20:47:10.423Z"
+  },
+  "czlonkowski/n8n-skills": {
+    "description": "n8n skillset for Claude Code to build flawless n8n workflows",
+    "fetchedAt": "2026-04-26T20:47:10.822Z"
+  },
+  "Cocoon-AI/architecture-diagram-generator": {
+    "description": "Generate beautiful dark-themed system architecture diagrams as standalone HTML/SVG files. Works as a Claude AI skill.",
+    "fetchedAt": "2026-04-26T20:47:11.260Z"
+  },
+  "remotion-dev/skills": {
+    "description": "Agent Skills",
+    "fetchedAt": "2026-04-26T20:47:11.723Z"
+  },
+  "chopratejas/headroom": {
+    "description": "The Context Optimization Layer for LLM Applications",
+    "fetchedAt": "2026-04-26T20:47:12.122Z"
+  },
+  "tornikebolokadze1-cyber/claude-code-setup": {
+    "description": "Production-grade Claude Code setup: 17 rules, 7 hooks, 7 templates, /setup command. One install — security, testing, CI/CD, and safety guardrails from day one.",
+    "fetchedAt": "2026-04-26T20:47:12.510Z"
+  },
+  "erekle1/georgian-payments-skills": {
+    "description": null,
+    "fetchedAt": "2026-04-26T20:47:12.897Z"
+  },
+  "modelcontextprotocol/servers": {
+    "description": "Model Context Protocol Servers",
+    "fetchedAt": "2026-04-26T20:47:13.352Z"
+  },
+  "upstash/context7": {
+    "description": "Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors",
+    "fetchedAt": "2026-04-26T20:47:13.812Z"
+  },
+  "github/github-mcp-server": {
+    "description": "GitHub's official MCP Server",
+    "fetchedAt": "2026-04-26T20:47:14.294Z"
+  },
+  "jlowin/fastmcp": {
+    "description": "🚀 The fast, Pythonic way to build MCP servers and clients.",
+    "fetchedAt": "2026-04-26T20:47:15.139Z"
+  },
+  "oraios/serena": {
+    "description": "A powerful MCP toolkit for coding, providing semantic retrieval and editing capabilities  - the IDE for your agent",
+    "fetchedAt": "2026-04-26T20:47:15.553Z"
+  },
+  "czlonkowski/n8n-mcp": {
+    "description": "A MCP for Claude Desktop / Claude Code / Windsurf / Cursor to build n8n workflows for you ",
+    "fetchedAt": "2026-04-26T20:47:15.988Z"
+  },
+  "GLips/Figma-Context-MCP": {
+    "description": "MCP server to provide Figma layout information to AI coding agents like Cursor",
+    "fetchedAt": "2026-04-26T20:47:16.369Z"
+  },
+  "tirth8205/code-review-graph": {
+    "description": "Local knowledge graph for Claude Code. Builds a persistent map of your codebase so Claude reads only what matters — 6.8× fewer tokens on reviews and up to 49× on daily coding tasks.",
+    "fetchedAt": "2026-04-26T20:47:16.761Z"
+  },
+  "exa-labs/exa-mcp-server": {
+    "description": "Exa MCP for web search and web crawling!",
+    "fetchedAt": "2026-04-26T20:47:17.225Z"
+  },
+  "makenotion/notion-mcp-server": {
+    "description": "Official Notion MCP Server",
+    "fetchedAt": "2026-04-26T20:47:17.680Z"
+  },
+  "jgraph/drawio-mcp": {
+    "description": null,
+    "fetchedAt": "2026-04-26T20:47:18.093Z"
+  },
+  "supabase-community/supabase-mcp": {
+    "description": "Connect Supabase to your AI assistants",
+    "fetchedAt": "2026-04-26T20:47:18.543Z"
+  },
+  "zcaceres/markdownify-mcp": {
+    "description": "A Model Context Protocol server for converting almost anything to Markdown",
+    "fetchedAt": "2026-04-26T20:47:18.941Z"
+  },
+  "perplexityai/modelcontextprotocol": {
+    "description": "The official MCP server implementation for the Perplexity API Platform",
+    "fetchedAt": "2026-04-26T20:47:19.415Z"
+  },
+  "louislva/claude-peers-mcp": {
+    "description": "Allow all your Claude Codes to message each other ad-hoc!",
+    "fetchedAt": "2026-04-26T20:47:19.808Z"
+  },
+  "tavily-ai/tavily-mcp": {
+    "description": "Production ready MCP server with real-time search, extract, map & crawl.",
+    "fetchedAt": "2026-04-26T20:47:20.276Z"
+  },
+  "stickerdaniel/linkedin-mcp-server": {
+    "description": "Open-source MCP server for LinkedIn. Give Claude and any MCP-compatible AI assistant access to profiles, companies, jobs, and messages.",
+    "fetchedAt": "2026-04-26T20:47:20.754Z"
+  },
+  "stripe/agent-toolkit": {
+    "description": "One-stop shop for building AI-powered products and businesses with Stripe.",
+    "fetchedAt": "2026-04-26T20:47:21.650Z"
+  },
+  "apify/apify-mcp-server": {
+    "description": "The Apify MCP server enables your AI agents to extract data from social media, search engines, maps, e-commerce sites, or any other website using thousands of ready-made scrapers, crawlers, and automation tools available on the Apify Store.",
+    "fetchedAt": "2026-04-26T20:47:22.139Z"
+  },
+  "microsoft/powerbi-modeling-mcp": {
+    "description": "The Power BI Modeling MCP Server, brings Power BI semantic modeling capabilities to your AI agents.",
+    "fetchedAt": "2026-04-26T20:47:22.673Z"
+  },
+  "getsentry/sentry-mcp": {
+    "description": "An MCP server for interacting with Sentry via LLMs.",
+    "fetchedAt": "2026-04-26T20:47:23.193Z"
+  },
+  "e2b-dev/mcp-server": {
+    "description": "Giving Claude ability to run code with E2B via MCP (Model Context Protocol)",
+    "fetchedAt": "2026-04-26T20:47:23.665Z"
+  },
+  "metricool/mcp-metricool": {
+    "description": "This is a Multi-Agent Collaboration Protocol (MCP) server for interacting with the Metricool API. It allows AI agents to access and analyze social media metrics and campaign data from your Metricool account.",
+    "fetchedAt": "2026-04-26T20:47:24.113Z"
+  },
+  "mendableai/firecrawl": {
+    "description": "🔥 The API to search, scrape, and interact with the web for AI",
+    "fetchedAt": "2026-04-26T20:47:24.811Z"
+  },
+  "browser-use/browser-use": {
+    "description": "🌐 Make websites accessible for AI agents. Automate tasks online with ease.",
+    "fetchedAt": "2026-04-26T20:47:25.262Z"
+  },
+  "unclecode/crawl4ai": {
+    "description": "🚀🤖 Crawl4AI: Open-source LLM Friendly Web Crawler & Scraper. Don't be shy, join here: https://discord.gg/jP8KfhDhyN",
+    "fetchedAt": "2026-04-26T20:47:25.648Z"
+  },
+  "microsoft/playwright-mcp": {
+    "description": "Playwright MCP server",
+    "fetchedAt": "2026-04-26T20:47:26.163Z"
+  },
+  "vercel-labs/agent-browser": {
+    "description": "Browser automation CLI for AI agents",
+    "fetchedAt": "2026-04-26T20:47:26.677Z"
+  },
+  "lightpanda-io/browser": {
+    "description": "Lightpanda: the headless browser designed for AI and automation",
+    "fetchedAt": "2026-04-26T20:47:27.094Z"
+  },
+  "browserbase/stagehand": {
+    "description": "The SDK For Browser Agents",
+    "fetchedAt": "2026-04-26T20:47:27.575Z"
+  },
+  "Panniantong/Agent-Reach": {
+    "description": "Give your AI agent eyes to see the entire internet. Read & search Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu — one CLI, zero API fees.",
+    "fetchedAt": "2026-04-26T20:47:27.947Z"
+  },
+  "jackwener/opencli": {
+    "description": "Make Any Website & Tool Your CLI. A universal CLI Hub and AI-native runtime. Transform any website, Electron app, or local binary into a standardized command-line interface. Built for AI Agents to discover, learn, and execute tools seamlessly via a unified AGENT.md integration.",
+    "fetchedAt": "2026-04-26T20:47:28.341Z"
+  },
+  "microsoft/playwright-cli": {
+    "description": "CLI for common Playwright actions. Record and generate Playwright code, inspect selectors and take screenshots.",
+    "fetchedAt": "2026-04-26T20:47:28.838Z"
+  },
+  "firecrawl/firecrawl-mcp-server": {
+    "description": "🔥 Official Firecrawl MCP Server - Adds powerful web scraping and search to Cursor, Claude and any other LLM clients.",
+    "fetchedAt": "2026-04-26T20:47:29.266Z"
+  },
+  "browser-use/browser-harness": {
+    "description": "Browser Harness | Self-healing harness that enables LLMs to complete any task.",
+    "fetchedAt": "2026-04-26T20:47:29.749Z"
+  },
+  "cloudflare/mcp-server-cloudflare": {
+    "description": null,
+    "fetchedAt": "2026-04-26T20:47:30.187Z"
+  },
+  "brightdata/brightdata-mcp": {
+    "description": "A powerful Model Context Protocol (MCP) server that provides an all-in-one solution for public web access.",
+    "fetchedAt": "2026-04-26T20:47:30.647Z"
+  },
+  "fkonovalov/rdrr": {
+    "description": "Convert any URL to clean markdown for AI agents.",
+    "fetchedAt": "2026-04-26T20:47:31.050Z"
+  },
+  "langchain-ai/langchain": {
+    "description": "The agent engineering platform",
+    "fetchedAt": "2026-04-26T20:47:31.588Z"
+  },
+  "nousresearch/hermes-agent": {
+    "description": "The agent that grows with you",
+    "fetchedAt": "2026-04-26T20:47:32.024Z"
+  },
+  "geekan/MetaGPT": {
+    "description": "🌟 The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming",
+    "fetchedAt": "2026-04-26T20:47:32.831Z"
+  },
+  "microsoft/autogen": {
+    "description": "A programming framework for agentic AI",
+    "fetchedAt": "2026-04-26T20:47:33.342Z"
+  },
+  "virattt/ai-hedge-fund": {
+    "description": "An AI Hedge Fund Team",
+    "fetchedAt": "2026-04-26T20:47:33.926Z"
+  },
+  "crewaiinc/crewai": {
+    "description": "Framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks.",
+    "fetchedAt": "2026-04-26T20:47:34.401Z"
+  },
+  "HKUDS/nanobot": {
+    "description": "\"🐈 nanobot: The Ultra-Lightweight Personal AI Agent\"",
+    "fetchedAt": "2026-04-26T20:47:35.017Z"
+  },
+  "agno-agi/agno": {
+    "description": "Build, run, manage agentic software at scale.",
+    "fetchedAt": "2026-04-26T20:47:35.670Z"
+  },
+  "stanfordnlp/dspy": {
+    "description": "DSPy: The framework for programming—not prompting—language models",
+    "fetchedAt": "2026-04-26T20:47:36.111Z"
+  },
+  "langchain-ai/langgraph": {
+    "description": "Build resilient language agents as graphs.",
+    "fetchedAt": "2026-04-26T20:47:36.565Z"
+  },
+  "microsoft/semantic-kernel": {
+    "description": "Integrate cutting-edge LLM technology quickly and easily into your apps",
+    "fetchedAt": "2026-04-26T20:47:37.073Z"
+  },
+  "huggingface/smolagents": {
+    "description": "🤗 smolagents: a barebones library for agents that think in code.",
+    "fetchedAt": "2026-04-26T20:47:37.554Z"
+  },
+  "openai/openai-agents-python": {
+    "description": "A lightweight, powerful framework for multi-agent workflows",
+    "fetchedAt": "2026-04-26T20:47:38.020Z"
+  },
+  "vercel/ai": {
+    "description": "The AI Toolkit for TypeScript. From the creators of Next.js, the AI SDK is a free open-source library for building AI-powered applications and agents ",
+    "fetchedAt": "2026-04-26T20:47:38.500Z"
+  },
+  "mastra-ai/mastra": {
+    "description": "From the team behind Gatsby, Mastra is a framework for building AI-powered applications and agents with a modern TypeScript stack.",
+    "fetchedAt": "2026-04-26T20:47:38.937Z"
+  },
+  "openai/swarm": {
+    "description": "Educational framework exploring ergonomic, lightweight multi-agent orchestration. Managed by OpenAI Solution team.",
+    "fetchedAt": "2026-04-26T20:47:39.411Z"
+  },
+  "coleam00/Archon": {
+    "description": "The first open-source harness builder for AI coding. Make AI coding deterministic and repeatable.",
+    "fetchedAt": "2026-04-26T20:47:39.807Z"
+  },
+  "pydantic/pydantic-ai": {
+    "description": "AI Agent Framework, the Pydantic way",
+    "fetchedAt": "2026-04-26T20:47:40.499Z"
+  },
+  "alibaba/OpenSandbox": {
+    "description": "Secure, Fast, and Extensible Sandbox runtime for AI agents.",
+    "fetchedAt": "2026-04-26T20:47:40.957Z"
+  },
+  "HKUDS/OpenSpace": {
+    "description": "\"OpenSpace: Make Your Agents: Smarter, Low-Cost, Self-Evolving\" -- Community: https://open-space.cloud/",
+    "fetchedAt": "2026-04-26T20:47:41.390Z"
+  },
+  "openclaw/openclaw": {
+    "description": "Your own personal AI assistant. Any OS. Any Platform. The lobster way. 🦞 ",
+    "fetchedAt": "2026-04-26T20:47:41.827Z"
+  },
+  "n8n-io/n8n": {
+    "description": "Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.",
+    "fetchedAt": "2026-04-26T20:47:42.481Z"
+  },
+  "langflow-ai/langflow": {
+    "description": "Langflow is a powerful tool for building and deploying AI-powered agents and workflows.",
+    "fetchedAt": "2026-04-26T20:47:42.928Z"
+  },
+  "langgenius/dify": {
+    "description": "Production-ready platform for agentic workflow development.",
+    "fetchedAt": "2026-04-26T20:47:43.386Z"
+  },
+  "open-webui/open-webui": {
+    "description": "User-friendly AI Interface (Supports Ollama, OpenAI API, ...)",
+    "fetchedAt": "2026-04-26T20:47:43.834Z"
+  },
+  "nomic-ai/gpt4all": {
+    "description": "GPT4All: Run Local LLMs on Any Device. Open-source and available for commercial use.",
+    "fetchedAt": "2026-04-26T20:47:44.302Z"
+  },
+  "lobehub/lobe-chat": {
+    "description": "The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent collaboration, effortless agent team design, and introducing agents as the unit of work interaction.",
+    "fetchedAt": "2026-04-26T20:47:45.122Z"
+  },
+  "Mintplex-Labs/anything-llm": {
+    "description": "The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration.",
+    "fetchedAt": "2026-04-26T20:47:45.530Z"
+  },
+  "paperclipai/paperclip": {
+    "description": "Open-source orchestration for zero-human companies",
+    "fetchedAt": "2026-04-26T20:47:45.947Z"
+  },
+  "666ghj/MiroFish": {
+    "description": "A Simple and Universal Swarm Intelligence Engine, Predicting Anything. 简洁通用的群体智能引擎，预测万物",
+    "fetchedAt": "2026-04-26T20:47:46.333Z"
+  },
+  "FlowiseAI/Flowise": {
+    "description": "Build AI Agents, Visually",
+    "fetchedAt": "2026-04-26T20:47:46.818Z"
+  },
+  "janhq/jan": {
+    "description": "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.",
+    "fetchedAt": "2026-04-26T20:47:47.293Z"
+  },
+  "danny-avila/LibreChat": {
+    "description": "Enhanced ChatGPT Clone: Features Agents, MCP, DeepSeek, Anthropic, AWS, OpenAI, Responses API, Azure, Groq, o1, GPT-5, Mistral, OpenRouter, Vertex AI, Gemini, Artifacts, AI model switching, message search, Code Interpreter, langchain, DALL-E-3, OpenAPI Actions, Functions, Secure Multi-User Auth, Presets, open-source for self-hosting. Active.",
+    "fetchedAt": "2026-04-26T20:47:47.684Z"
+  },
+  "khoj-ai/khoj": {
+    "description": "Your AI second brain. Self-hostable. Get answers from the web or your docs. Build custom agents, schedule automations, do deep research. Turn any online or local LLM into your personal, autonomous AI (gpt, claude, gemini, llama, qwen, mistral). Get started - free.",
+    "fetchedAt": "2026-04-26T20:47:48.157Z"
+  },
+  "ItzCrazyKns/Perplexica": {
+    "description": "Vane is an AI-powered answering engine.",
+    "fetchedAt": "2026-04-26T20:47:48.810Z"
+  },
+  "activepieces/activepieces": {
+    "description": "AI Agents & MCPs & AI Workflow Automation • (~400 MCP servers for AI agents) • AI Automation / AI Agent with MCPs • AI Workflows & AI Agents • MCPs for AI Agents",
+    "fetchedAt": "2026-04-26T20:47:49.246Z"
+  },
+  "HKUDS/DeepTutor": {
+    "description": "\"DeepTutor: Agent-Native Personalized Learning Assistant\"",
+    "fetchedAt": "2026-04-26T20:47:49.698Z"
+  },
+  "multica-ai/multica": {
+    "description": "The open-source managed agents platform. Turn coding agents into real teammates — assign tasks, track progress, compound skills.",
+    "fetchedAt": "2026-04-26T20:47:50.327Z"
+  },
+  "Fincept-Corporation/FinceptTerminal": {
+    "description": "FinceptTerminal is a modern finance application offering advanced market analytics, investment research, and economic data tools, designed for interactive exploration and data-driven decision-making in a user-friendly environment.",
+    "fetchedAt": "2026-04-26T20:47:50.777Z"
+  },
+  "rowboatlabs/rowboat": {
+    "description": "Open-source AI coworker, with memory",
+    "fetchedAt": "2026-04-26T20:47:51.237Z"
+  },
+  "getcompanion-ai/feynman": {
+    "description": null,
+    "fetchedAt": "2026-04-26T20:47:51.882Z"
+  },
+  "cloudflare/agentic-inbox": {
+    "description": "A self-hosted email client with an AI agent, running entirely on Cloudflare Workers",
+    "fetchedAt": "2026-04-26T20:47:52.363Z"
+  },
+  "infiniflow/ragflow": {
+    "description": "RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs",
+    "fetchedAt": "2026-04-26T20:47:52.798Z"
+  },
+  "mem0ai/mem0": {
+    "description": "Universal memory layer for AI Agents",
+    "fetchedAt": "2026-04-26T20:47:53.252Z"
+  },
+  "milla-jovovich/mempalace": {
+    "description": "The best-benchmarked open-source AI memory system. And it's free.",
+    "fetchedAt": "2026-04-26T20:47:54.043Z"
+  },
+  "run-llama/llama_index": {
+    "description": "LlamaIndex is the leading document agent and OCR platform",
+    "fetchedAt": "2026-04-26T20:47:54.670Z"
+  },
+  "milvus-io/milvus": {
+    "description": "Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search",
+    "fetchedAt": "2026-04-26T20:47:55.119Z"
+  },
+  "hkuds/lightrag": {
+    "description": "[EMNLP2025] \"LightRAG: Simple and Fast Retrieval-Augmented Generation\"",
+    "fetchedAt": "2026-04-26T20:47:55.557Z"
+  },
+  "qdrant/qdrant": {
+    "description": "Qdrant - High-performance, massive-scale Vector Database and Vector Search Engine for the next generation of AI. Also available in the cloud https://cloud.qdrant.io/",
+    "fetchedAt": "2026-04-26T20:47:56.040Z"
+  },
+  "chroma-core/chroma": {
+    "description": "Data infrastructure for AI",
+    "fetchedAt": "2026-04-26T20:47:56.525Z"
+  },
+  "getzep/graphiti": {
+    "description": "Build Real-Time Knowledge Graphs for AI Agents",
+    "fetchedAt": "2026-04-26T20:47:57.081Z"
+  },
+  "letta-ai/letta": {
+    "description": "Letta is the platform for building stateful agents: AI with advanced memory that can learn and self-improve over time.",
+    "fetchedAt": "2026-04-26T20:47:57.508Z"
+  },
+  "HKUDS/RAG-Anything": {
+    "description": "\"RAG-Anything: All-in-One RAG Framework\"",
+    "fetchedAt": "2026-04-26T20:47:58.182Z"
+  },
+  "garrytan/gbrain": {
+    "description": "Garry's Opinionated OpenClaw/Hermes Agent Brain",
+    "fetchedAt": "2026-04-26T20:47:58.573Z"
+  },
+  "vectorize-io/hindsight": {
+    "description": "Hindsight: Agent Memory That  Learns",
+    "fetchedAt": "2026-04-26T20:47:59.056Z"
+  },
+  "coleam00/mcp-crawl4ai-rag": {
+    "description": "Web Crawling and RAG Capabilities for AI Agents and AI Coding Assistants",
+    "fetchedAt": "2026-04-26T20:47:59.451Z"
+  },
+  "dcostenco/prism-mcp": {
+    "description": "The Mind Palace for AI Agents - HIPAA-hardened Cognitive Architecture with on-device LLM (prism-coder:7b), Hebbian learning, ACT-R spreading activation, adversarial evaluation, persistent memory, multi-agent Hivemind and visual dashboard. Zero API keys required.",
+    "fetchedAt": "2026-04-26T20:47:59.861Z"
+  },
+  "ollama/ollama": {
+    "description": "Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models.",
+    "fetchedAt": "2026-04-26T20:48:00.319Z"
+  },
+  "huggingface/transformers": {
+    "description": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training. ",
+    "fetchedAt": "2026-04-26T20:48:00.814Z"
+  },
+  "comfy-org/ComfyUI": {
+    "description": "The most powerful and modular diffusion model GUI, api and backend with a graph/nodes interface.",
+    "fetchedAt": "2026-04-26T20:48:01.288Z"
+  },
+  "ggml-org/llama.cpp": {
+    "description": "LLM inference in C/C++",
+    "fetchedAt": "2026-04-26T20:48:01.725Z"
+  },
+  "vllm-project/vllm": {
+    "description": "A high-throughput and memory-efficient inference and serving engine for LLMs",
+    "fetchedAt": "2026-04-26T20:48:02.197Z"
+  },
+  "CompVis/stable-diffusion": {
+    "description": "A latent text-to-image diffusion model",
+    "fetchedAt": "2026-04-26T20:48:02.836Z"
+  },
+  "unslothai/unsloth": {
+    "description": "Web UI for training and running open models like Gemma 4, Qwen3.5, DeepSeek, gpt-oss locally.",
+    "fetchedAt": "2026-04-26T20:48:03.308Z"
+  },
+  "ggerganov/whisper.cpp": {
+    "description": "Port of OpenAI's Whisper model in C/C++",
+    "fetchedAt": "2026-04-26T20:48:04.135Z"
+  },
+  "mudler/LocalAI": {
+    "description": "LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required.",
+    "fetchedAt": "2026-04-26T20:48:04.724Z"
+  },
+  "coqui-ai/TTS": {
+    "description": "🐸💬 - a deep learning toolkit for Text-to-Speech, battle-tested in research and production",
+    "fetchedAt": "2026-04-26T20:48:05.372Z"
+  },
+  "suno-ai/bark": {
+    "description": "🔊 Text-Prompted Generative Audio Model",
+    "fetchedAt": "2026-04-26T20:48:05.851Z"
+  },
+  "huggingface/diffusers": {
+    "description": "🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch.",
+    "fetchedAt": "2026-04-26T20:48:06.344Z"
+  },
+  "sgl-project/sglang": {
+    "description": "SGLang is a high-performance serving framework for large language models and multimodal models.",
+    "fetchedAt": "2026-04-26T20:48:06.789Z"
+  },
+  "black-forest-labs/flux": {
+    "description": "Official inference repo for FLUX.1 models",
+    "fetchedAt": "2026-04-26T20:48:07.414Z"
+  },
+  "googleworkspace/cli": {
+    "description": "Google Workspace CLI — one command-line tool for Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin, and more. Dynamically built from Google Discovery Service. Includes AI agent skills.",
+    "fetchedAt": "2026-04-26T20:48:07.889Z"
+  },
+  "toon-format/toon": {
+    "description": "🎒 Token-Oriented Object Notation (TOON) – Compact, human-readable, schema-aware JSON for LLM prompts. Spec, benchmarks, TypeScript SDK.",
+    "fetchedAt": "2026-04-26T20:48:08.323Z"
+  },
+  "shiyu-coder/Kronos": {
+    "description": "Kronos: A Foundation Model for the Language of Financial Markets",
+    "fetchedAt": "2026-04-26T20:48:08.711Z"
+  },
+  "OpenBMB/VoxCPM": {
+    "description": "VoxCPM2: Tokenizer-Free TTS for Multilingual Speech Generation, Creative Voice Design, and True-to-Life Cloning",
+    "fetchedAt": "2026-04-26T20:48:09.152Z"
+  },
+  "Tencent-Hunyuan/HunyuanVideo": {
+    "description": "HunyuanVideo: A Systematic Framework For Large Video Generation Model",
+    "fetchedAt": "2026-04-26T20:48:09.628Z"
+  },
+  "teng-lin/notebooklm-py": {
+    "description": "Unofficial Python API and agentic skill for Google NotebookLM. Full programmatic access to NotebookLM's features—including capabilities the web UI doesn't expose—via Python, CLI, and AI agents like Claude Code, Codex, and OpenClaw.",
+    "fetchedAt": "2026-04-26T20:48:10.017Z"
+  },
+  "heygen-com/hyperframes": {
+    "description": "Write HTML. Render video. Built for agents.",
+    "fetchedAt": "2026-04-26T20:48:10.474Z"
+  },
+  "lmstudio-ai/lms": {
+    "description": "LM Studio CLI",
+    "fetchedAt": "2026-04-26T20:48:10.918Z"
+  },
+  "KoljaB/RealtimeTTS": {
+    "description": "Converts text to speech in realtime",
+    "fetchedAt": "2026-04-26T20:48:11.313Z"
+  },
+  "browser-use/video-use": {
+    "description": "Edit videos with coding agents",
+    "fetchedAt": "2026-04-26T20:48:11.783Z"
+  },
+  "codecrafters-io/build-your-own-x": {
+    "description": "Master programming by recreating your favorite technologies from scratch.",
+    "fetchedAt": "2026-04-26T20:48:12.253Z"
+  },
+  "public-apis/public-apis": {
+    "description": "A collective list of free APIs",
+    "fetchedAt": "2026-04-26T20:48:12.734Z"
+  },
+  "x1xhlol/system-prompts-and-models-of-ai-tools": {
+    "description": "FULL Augment Code, Claude Code, Cluely, CodeBuddy, Comet, Cursor, Devin AI, Junie, Kiro, Leap.new, Lovable, Manus, NotionAI, Orchids.app, Perplexity, Poke, Qoder, Replit, Same.dev, Trae, Traycer AI, VSCode Agent, Warp.dev, Windsurf, Xcode, Z.ai Code, Dia & v0. (And other Open Sourced) System Prompts, Internal Tools & AI Models",
+    "fetchedAt": "2026-04-26T20:48:13.138Z"
+  },
+  "rasbt/LLMs-from-scratch": {
+    "description": "Implement a ChatGPT-like LLM in PyTorch from scratch, step by step",
+    "fetchedAt": "2026-04-26T20:48:13.551Z"
+  },
+  "karpathy/autoresearch": {
+    "description": "AI agents running research on single-GPU nanochat training automatically",
+    "fetchedAt": "2026-04-26T20:48:13.954Z"
+  },
+  "google-labs-code/design.md": {
+    "description": "A format specification for describing a visual identity to coding agents. DESIGN.md gives agents a persistent, structured understanding of a design system.",
+    "fetchedAt": "2026-04-26T20:48:14.432Z"
+  },
+  "VoltAgent/awesome-design-md": {
+    "description": "A collection of DESIGN.md files inspired by popular brand design systems. Drop one into your project and let coding agents generate a matching UI.",
+    "fetchedAt": "2026-04-26T20:48:14.861Z"
+  },
+  "anthropics/anthropic-cookbook": {
+    "description": "A collection of notebooks/recipes showcasing some fun and effective ways of using Claude.",
+    "fetchedAt": "2026-04-26T20:48:15.771Z"
+  },
+  "hesreallyhim/awesome-claude-code": {
+    "description": "A curated list of awesome skills, hooks, slash-commands, agent orchestrators, applications, and plugins for Claude Code by Anthropic",
+    "fetchedAt": "2026-04-26T20:48:16.160Z"
+  },
+  "luongnv89/claude-howto": {
+    "description": "A visual, example-driven guide to Claude Code — from basic concepts to advanced agents, with copy-paste templates that bring immediate value.",
+    "fetchedAt": "2026-04-26T20:48:16.521Z"
+  },
+  "cheahjs/free-llm-api-resources": {
+    "description": "A list of free LLM inference resources accessible via API.",
+    "fetchedAt": "2026-04-26T20:48:16.913Z"
+  }
+}

--- a/mcp/data/repos.json
+++ b/mcp/data/repos.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-26T18:19:07.239Z",
+  "generated": "2026-04-26T20:48:44.446Z",
   "totalRepos": 179,
   "categories": [
     {
@@ -75,7 +75,8 @@
       "starsNumeric": 187000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "The repo is finally unlocked. enjoy the party! The fastest repo in history to surpass 100K stars ⭐. Join Discord: https://discord.gg/5TUQKqFWd Built in Rust using oh-my-codex."
     },
     {
       "name": "opencode",
@@ -85,7 +86,8 @@
       "starsNumeric": 148000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "The open source coding agent."
     },
     {
       "name": "Gemini CLI",
@@ -95,7 +97,8 @@
       "starsNumeric": 102000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "An open-source AI agent that brings the power of Gemini directly into your terminal."
     },
     {
       "name": "Codex CLI",
@@ -105,7 +108,8 @@
       "starsNumeric": 77000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Lightweight coding agent that runs in your terminal"
     },
     {
       "name": "OpenHands",
@@ -115,7 +119,8 @@
       "starsNumeric": 71000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "🙌 OpenHands: AI-Driven Development"
     },
     {
       "name": "Cline",
@@ -125,7 +130,8 @@
       "starsNumeric": 60000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Autonomous coding agent right in your IDE, capable of creating/editing files, executing commands, using the browser, and more with your permission every step of the way."
     },
     {
       "name": "omo (ex-oh-my-openagent)",
@@ -135,7 +141,8 @@
       "starsNumeric": 53000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "omo; the best agent harness - previously oh-my-opencode"
     },
     {
       "name": "Aider",
@@ -145,7 +152,8 @@
       "starsNumeric": 43000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "aider is AI pair programming in your terminal"
     },
     {
       "name": "Goose",
@@ -155,7 +163,8 @@
       "starsNumeric": 43000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM"
     },
     {
       "name": "Tabby",
@@ -165,7 +174,8 @@
       "starsNumeric": 33000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Self-hosted AI coding assistant"
     },
     {
       "name": "Continue.dev",
@@ -175,7 +185,8 @@
       "starsNumeric": 32000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI"
     },
     {
       "name": "Void",
@@ -185,7 +196,8 @@
       "starsNumeric": 28000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": null
     },
     {
       "name": "GitNexus",
@@ -195,7 +207,8 @@
       "starsNumeric": 28000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "GitNexus: The Zero-Server Code Intelligence Engine -       GitNexus is a client-side knowledge graph creator that runs entirely in your browser. Drop in a GitHub repo or ZIP file, and get an interactive knowledge graph wit a built in Graph RAG Agent. Perfect for code exploration"
     },
     {
       "name": "Taskmaster",
@@ -205,7 +218,8 @@
       "starsNumeric": 26000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others."
     },
     {
       "name": "OpenClaude",
@@ -215,7 +229,8 @@
       "starsNumeric": 23000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Open Claude Is Open-source coding-agent CLI for OpenAI, Gemini, DeepSeek, Ollama, Codex, GitHub Models, and 200+ models via OpenAI-compatible APIs."
     },
     {
       "name": "Qwen Code",
@@ -225,7 +240,8 @@
       "starsNumeric": 23000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "An open-source AI agent that lives in your terminal."
     },
     {
       "name": "Roo Code",
@@ -235,7 +251,8 @@
       "starsNumeric": 23000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Roo Code gives you a whole dev team of AI agents in your code editor."
     },
     {
       "name": "Kilocode",
@@ -245,7 +262,8 @@
       "starsNumeric": 18000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent."
     },
     {
       "name": "Codex Plugin",
@@ -255,7 +273,8 @@
       "starsNumeric": 15000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Use Codex from Claude Code to review code or delegate tasks."
     },
     {
       "name": "cmux",
@@ -265,7 +284,8 @@
       "starsNumeric": 15000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents"
     },
     {
       "name": "free-claude-code",
@@ -275,7 +295,8 @@
       "starsNumeric": 11000,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "Use claude-code for free in the terminal, VSCode extension or via discord like openclaw"
     },
     {
       "name": "ml-intern",
@@ -285,7 +306,8 @@
       "starsNumeric": 4200,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "🤗 ml-intern: an open-source ML engineer that reads papers, trains models, and ships ML models"
     },
     {
       "name": "Open Agents",
@@ -295,7 +317,8 @@
       "starsNumeric": 4100,
       "categorySlug": "coding",
       "categoryEmoji": "🤖",
-      "categoryGeorgian": "კოდინგ აგენტები"
+      "categoryGeorgian": "კოდინგ აგენტები",
+      "descriptionEn": "An open source template for building cloud agents."
     },
     {
       "name": "Superpowers",
@@ -305,7 +328,8 @@
       "starsNumeric": 165000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "An agentic skills framework & software development methodology that works."
     },
     {
       "name": "Everything Claude Code",
@@ -315,7 +339,8 @@
       "starsNumeric": 165000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "The agent harness performance optimization system. Skills, instincts, memory, security, and research-first development for Claude Code, Codex, Opencode, Cursor and beyond."
     },
     {
       "name": "Spec Kit",
@@ -325,7 +350,8 @@
       "starsNumeric": 90000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "💫 Toolkit to help you get started with Spec-Driven Development"
     },
     {
       "name": "Karpathy Skills",
@@ -335,7 +361,8 @@
       "starsNumeric": 80000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "A single CLAUDE.md file to improve Claude Code behavior, derived from Andrej Karpathy's observations on LLM coding pitfalls."
     },
     {
       "name": "UI UX Pro Max",
@@ -345,7 +372,8 @@
       "starsNumeric": 69000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "An AI SKILL that provide design intelligence for building professional UI/UX multiple platforms"
     },
     {
       "name": "Claude Mem",
@@ -355,7 +383,8 @@
       "starsNumeric": 66000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "A Claude Code plugin that automatically captures everything Claude does during your coding sessions, compresses it with AI (using Claude's agent-sdk), and injects relevant context back into future sessions."
     },
     {
       "name": "GSD (Get Shit Done)",
@@ -365,7 +394,8 @@
       "starsNumeric": 56000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code by TÂCHES."
     },
     {
       "name": "Caveman",
@@ -375,7 +405,8 @@
       "starsNumeric": 44000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "🪨 why use many token when few token do trick — Claude Code skill that cuts 65% of tokens by talking like caveman"
     },
     {
       "name": "Career-Ops",
@@ -385,7 +416,8 @@
       "starsNumeric": 38000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "AI-powered job search system built on Claude Code. 14 skill modes, Go dashboard, PDF generation, batch processing."
     },
     {
       "name": "Graphify",
@@ -395,7 +427,8 @@
       "starsNumeric": 33000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, GitHub Copilot CLI, OpenClaw, Factory Droid, Trae, Google Antigravity). Turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph"
     },
     {
       "name": "RuFlo (ex-Claude Flow)",
@@ -405,7 +438,8 @@
       "starsNumeric": 33000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "🌊 The leading agent orchestration platform for Claude. Deploy intelligent multi-agent swarms, coordinate autonomous workflows, and build conversational AI systems. Features    enterprise-grade architecture, distributed swarm intelligence, RAG integration, and native Claude Code / Codex Integration"
     },
     {
       "name": "Oh My ClaudeCode",
@@ -415,7 +449,8 @@
       "starsNumeric": 30000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Teams-first Multi-agent orchestration for Claude Code"
     },
     {
       "name": "Obsidian Skills",
@@ -425,7 +460,8 @@
       "starsNumeric": 26000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Agent skills for Obsidian. Teach your agent to use Markdown, Bases, JSON Canvas, and use the CLI."
     },
     {
       "name": "last30days-skill",
@@ -435,7 +471,8 @@
       "starsNumeric": 23800,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "AI agent skill that researches any topic across Reddit, X, YouTube, HN, Polymarket, and the web - then synthesizes a grounded summary"
     },
     {
       "name": "Agent Skills",
@@ -445,7 +482,8 @@
       "starsNumeric": 21000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Production-grade engineering skills for AI coding agents."
     },
     {
       "name": "Claude Plugins Official",
@@ -455,7 +493,8 @@
       "starsNumeric": 17000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Official, Anthropic-managed directory of high quality Claude Code Plugins."
     },
     {
       "name": "Agent Skills Spec",
@@ -465,7 +504,8 @@
       "starsNumeric": 16000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Specification and documentation for Agent Skills"
     },
     {
       "name": "Claude Code Game Studios",
@@ -475,7 +515,8 @@
       "starsNumeric": 16000,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Turn Claude Code into a full game dev studio — 49 AI agents, 72 workflow skills, and a complete coordination system mirroring real studio hierarchy."
     },
     {
       "name": "n8n Skills",
@@ -485,7 +526,8 @@
       "starsNumeric": 4600,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "n8n skillset for Claude Code to build flawless n8n workflows"
     },
     {
       "name": "Architecture Diagram Generator",
@@ -495,7 +537,8 @@
       "starsNumeric": 4300,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Generate beautiful dark-themed system architecture diagrams as standalone HTML/SVG files. Works as a Claude AI skill."
     },
     {
       "name": "Remotion Skills",
@@ -505,7 +548,8 @@
       "starsNumeric": 2900,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Agent Skills"
     },
     {
       "name": "Headroom",
@@ -515,7 +559,8 @@
       "starsNumeric": 1500,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "The Context Optimization Layer for LLM Applications"
     },
     {
       "name": "Claude Code Setup",
@@ -525,7 +570,8 @@
       "starsNumeric": 9,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": "Production-grade Claude Code setup: 17 rules, 7 hooks, 7 templates, /setup command. One install — security, testing, CI/CD, and safety guardrails from day one."
     },
     {
       "name": "Georgian Payments Skills",
@@ -535,7 +581,8 @@
       "starsNumeric": 7,
       "categorySlug": "plugins",
       "categoryEmoji": "⚡",
-      "categoryGeorgian": "Claude Code პლაგინები და უნარები"
+      "categoryGeorgian": "Claude Code პლაგინები და უნარები",
+      "descriptionEn": null
     },
     {
       "name": "MCP Servers",
@@ -545,7 +592,8 @@
       "starsNumeric": 84000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Model Context Protocol Servers"
     },
     {
       "name": "Context7",
@@ -555,7 +603,8 @@
       "starsNumeric": 53000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Context7 Platform -- Up-to-date code documentation for LLMs and AI code editors"
     },
     {
       "name": "GitHub MCP",
@@ -565,7 +614,8 @@
       "starsNumeric": 29000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "GitHub's official MCP Server"
     },
     {
       "name": "FastMCP",
@@ -575,7 +625,8 @@
       "starsNumeric": 24000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "🚀 The fast, Pythonic way to build MCP servers and clients."
     },
     {
       "name": "Serena",
@@ -585,7 +636,8 @@
       "starsNumeric": 23000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "A powerful MCP toolkit for coding, providing semantic retrieval and editing capabilities  - the IDE for your agent"
     },
     {
       "name": "n8n-MCP",
@@ -595,7 +647,8 @@
       "starsNumeric": 18000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "A MCP for Claude Desktop / Claude Code / Windsurf / Cursor to build n8n workflows for you "
     },
     {
       "name": "Figma Context MCP",
@@ -605,7 +658,8 @@
       "starsNumeric": 14000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "MCP server to provide Figma layout information to AI coding agents like Cursor"
     },
     {
       "name": "Code Review Graph",
@@ -615,7 +669,8 @@
       "starsNumeric": 12000,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Local knowledge graph for Claude Code. Builds a persistent map of your codebase so Claude reads only what matters — 6.8× fewer tokens on reviews and up to 49× on daily coding tasks."
     },
     {
       "name": "Exa MCP",
@@ -625,7 +680,8 @@
       "starsNumeric": 4300,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Exa MCP for web search and web crawling!"
     },
     {
       "name": "Notion MCP",
@@ -635,7 +691,8 @@
       "starsNumeric": 4300,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Official Notion MCP Server"
     },
     {
       "name": "Draw.io MCP",
@@ -645,7 +702,8 @@
       "starsNumeric": 3200,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": null
     },
     {
       "name": "Supabase MCP",
@@ -655,7 +713,8 @@
       "starsNumeric": 2600,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Connect Supabase to your AI assistants"
     },
     {
       "name": "Markdownify MCP",
@@ -665,7 +724,8 @@
       "starsNumeric": 2600,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "A Model Context Protocol server for converting almost anything to Markdown"
     },
     {
       "name": "Perplexity MCP",
@@ -675,7 +735,8 @@
       "starsNumeric": 2100,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "The official MCP server implementation for the Perplexity API Platform"
     },
     {
       "name": "Claude Peers MCP",
@@ -685,7 +746,8 @@
       "starsNumeric": 1900,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Allow all your Claude Codes to message each other ad-hoc!"
     },
     {
       "name": "Tavily MCP",
@@ -695,7 +757,8 @@
       "starsNumeric": 1800,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Production ready MCP server with real-time search, extract, map & crawl."
     },
     {
       "name": "LinkedIn MCP",
@@ -705,7 +768,8 @@
       "starsNumeric": 1700,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Open-source MCP server for LinkedIn. Give Claude and any MCP-compatible AI assistant access to profiles, companies, jobs, and messages."
     },
     {
       "name": "Stripe MCP",
@@ -715,7 +779,8 @@
       "starsNumeric": 1500,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "One-stop shop for building AI-powered products and businesses with Stripe."
     },
     {
       "name": "Apify MCP",
@@ -725,7 +790,8 @@
       "starsNumeric": 1100,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "The Apify MCP server enables your AI agents to extract data from social media, search engines, maps, e-commerce sites, or any other website using thousands of ready-made scrapers, crawlers, and automation tools available on the Apify Store."
     },
     {
       "name": "Power BI Modeling MCP",
@@ -735,7 +801,8 @@
       "starsNumeric": 677,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "The Power BI Modeling MCP Server, brings Power BI semantic modeling capabilities to your AI agents."
     },
     {
       "name": "Sentry MCP",
@@ -745,7 +812,8 @@
       "starsNumeric": 666,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "An MCP server for interacting with Sentry via LLMs."
     },
     {
       "name": "E2B MCP",
@@ -755,7 +823,8 @@
       "starsNumeric": 393,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "Giving Claude ability to run code with E2B via MCP (Model Context Protocol)"
     },
     {
       "name": "Metricool MCP",
@@ -765,7 +834,8 @@
       "starsNumeric": 36,
       "categorySlug": "mcp",
       "categoryEmoji": "🔌",
-      "categoryGeorgian": "MCP ინტეგრაციები"
+      "categoryGeorgian": "MCP ინტეგრაციები",
+      "descriptionEn": "This is a Multi-Agent Collaboration Protocol (MCP) server for interacting with the Metricool API. It allows AI agents to access and analyze social media metrics and campaign data from your Metricool account."
     },
     {
       "name": "Firecrawl",
@@ -775,7 +845,8 @@
       "starsNumeric": 111000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "🔥 The API to search, scrape, and interact with the web for AI"
     },
     {
       "name": "Browser Use",
@@ -785,7 +856,8 @@
       "starsNumeric": 89000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "🌐 Make websites accessible for AI agents. Automate tasks online with ease."
     },
     {
       "name": "Crawl4AI",
@@ -795,7 +867,8 @@
       "starsNumeric": 64000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "🚀🤖 Crawl4AI: Open-source LLM Friendly Web Crawler & Scraper. Don't be shy, join here: https://discord.gg/jP8KfhDhyN"
     },
     {
       "name": "Playwright MCP",
@@ -805,7 +878,8 @@
       "starsNumeric": 31000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Playwright MCP server"
     },
     {
       "name": "Agent Browser",
@@ -815,7 +889,8 @@
       "starsNumeric": 30000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Browser automation CLI for AI agents"
     },
     {
       "name": "Lightpanda",
@@ -825,7 +900,8 @@
       "starsNumeric": 29000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Lightpanda: the headless browser designed for AI and automation"
     },
     {
       "name": "Stagehand",
@@ -835,7 +911,8 @@
       "starsNumeric": 22000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "The SDK For Browser Agents"
     },
     {
       "name": "Agent-Reach",
@@ -845,7 +922,8 @@
       "starsNumeric": 18000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Give your AI agent eyes to see the entire internet. Read & search Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu — one CLI, zero API fees."
     },
     {
       "name": "opencli",
@@ -855,7 +933,8 @@
       "starsNumeric": 17000,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Make Any Website & Tool Your CLI. A universal CLI Hub and AI-native runtime. Transform any website, Electron app, or local binary into a standardized command-line interface. Built for AI Agents to discover, learn, and execute tools seamlessly via a unified AGENT.md integration."
     },
     {
       "name": "Playwright CLI",
@@ -865,7 +944,8 @@
       "starsNumeric": 9200,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "CLI for common Playwright actions. Record and generate Playwright code, inspect selectors and take screenshots."
     },
     {
       "name": "Firecrawl MCP Server",
@@ -875,7 +955,8 @@
       "starsNumeric": 6100,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "🔥 Official Firecrawl MCP Server - Adds powerful web scraping and search to Cursor, Claude and any other LLM clients."
     },
     {
       "name": "Browser Harness",
@@ -885,7 +966,8 @@
       "starsNumeric": 5900,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Browser Harness | Self-healing harness that enables LLMs to complete any task."
     },
     {
       "name": "Cloudflare MCP",
@@ -895,7 +977,8 @@
       "starsNumeric": 3700,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": null
     },
     {
       "name": "Bright Data MCP",
@@ -905,7 +988,8 @@
       "starsNumeric": 2300,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "A powerful Model Context Protocol (MCP) server that provides an all-in-one solution for public web access."
     },
     {
       "name": "rdrr",
@@ -915,7 +999,8 @@
       "starsNumeric": 138,
       "categorySlug": "scraping",
       "categoryEmoji": "🕷️",
-      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი"
+      "categoryGeorgian": "ვებ სკრეიპინგი და ბრაუზერი",
+      "descriptionEn": "Convert any URL to clean markdown for AI agents."
     },
     {
       "name": "LangChain",
@@ -925,7 +1010,8 @@
       "starsNumeric": 134000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "The agent engineering platform"
     },
     {
       "name": "Hermes-agent",
@@ -935,7 +1021,8 @@
       "starsNumeric": 113000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "The agent that grows with you"
     },
     {
       "name": "MetaGPT",
@@ -945,7 +1032,8 @@
       "starsNumeric": 67000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "🌟 The Multi-Agent Framework: First AI Software Company, Towards Natural Language Programming"
     },
     {
       "name": "AutoGen",
@@ -955,7 +1043,8 @@
       "starsNumeric": 57000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "A programming framework for agentic AI"
     },
     {
       "name": "AI Hedge Fund",
@@ -965,7 +1054,8 @@
       "starsNumeric": 57000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "An AI Hedge Fund Team"
     },
     {
       "name": "CrewAI",
@@ -975,7 +1065,8 @@
       "starsNumeric": 49000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Framework for orchestrating role-playing, autonomous AI agents. By fostering collaborative intelligence, CrewAI empowers agents to work together seamlessly, tackling complex tasks."
     },
     {
       "name": "nanobot",
@@ -985,7 +1076,8 @@
       "starsNumeric": 40000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "\"🐈 nanobot: The Ultra-Lightweight Personal AI Agent\""
     },
     {
       "name": "agno",
@@ -995,7 +1087,8 @@
       "starsNumeric": 39000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Build, run, manage agentic software at scale."
     },
     {
       "name": "DSPy",
@@ -1005,7 +1098,8 @@
       "starsNumeric": 34000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "DSPy: The framework for programming—not prompting—language models"
     },
     {
       "name": "LangGraph",
@@ -1015,7 +1109,8 @@
       "starsNumeric": 30000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Build resilient language agents as graphs."
     },
     {
       "name": "Semantic Kernel",
@@ -1025,7 +1120,8 @@
       "starsNumeric": 27000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Integrate cutting-edge LLM technology quickly and easily into your apps"
     },
     {
       "name": "smolagents",
@@ -1035,7 +1131,8 @@
       "starsNumeric": 26000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "🤗 smolagents: a barebones library for agents that think in code."
     },
     {
       "name": "OpenAI Agents SDK",
@@ -1045,7 +1142,8 @@
       "starsNumeric": 24000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "A lightweight, powerful framework for multi-agent workflows"
     },
     {
       "name": "Vercel AI SDK",
@@ -1055,7 +1153,8 @@
       "starsNumeric": 23000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "The AI Toolkit for TypeScript. From the creators of Next.js, the AI SDK is a free open-source library for building AI-powered applications and agents "
     },
     {
       "name": "Mastra",
@@ -1065,7 +1164,8 @@
       "starsNumeric": 23000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "From the team behind Gatsby, Mastra is a framework for building AI-powered applications and agents with a modern TypeScript stack."
     },
     {
       "name": "Swarm",
@@ -1075,7 +1175,8 @@
       "starsNumeric": 21000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Educational framework exploring ergonomic, lightweight multi-agent orchestration. Managed by OpenAI Solution team."
     },
     {
       "name": "Archon",
@@ -1085,7 +1186,8 @@
       "starsNumeric": 19000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "The first open-source harness builder for AI coding. Make AI coding deterministic and repeatable."
     },
     {
       "name": "Pydantic AI",
@@ -1095,7 +1197,8 @@
       "starsNumeric": 16000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "AI Agent Framework, the Pydantic way"
     },
     {
       "name": "OpenSandbox",
@@ -1105,7 +1208,8 @@
       "starsNumeric": 10000,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "Secure, Fast, and Extensible Sandbox runtime for AI agents."
     },
     {
       "name": "OpenSpace",
@@ -1115,7 +1219,8 @@
       "starsNumeric": 5700,
       "categorySlug": "frameworks",
       "categoryEmoji": "🧬",
-      "categoryGeorgian": "AI აგენტების ფრეიმვორკები"
+      "categoryGeorgian": "AI აგენტების ფრეიმვორკები",
+      "descriptionEn": "\"OpenSpace: Make Your Agents: Smarter, Low-Cost, Self-Evolving\" -- Community: https://open-space.cloud/"
     },
     {
       "name": "OpenClaw",
@@ -1125,7 +1230,8 @@
       "starsNumeric": 362000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Your own personal AI assistant. Any OS. Any Platform. The lobster way. 🦞 "
     },
     {
       "name": "n8n",
@@ -1135,7 +1241,8 @@
       "starsNumeric": 185000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations."
     },
     {
       "name": "Langflow",
@@ -1145,7 +1252,8 @@
       "starsNumeric": 147000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Langflow is a powerful tool for building and deploying AI-powered agents and workflows."
     },
     {
       "name": "Dify",
@@ -1155,7 +1263,8 @@
       "starsNumeric": 138000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Production-ready platform for agentic workflow development."
     },
     {
       "name": "Open WebUI",
@@ -1165,7 +1274,8 @@
       "starsNumeric": 133000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "User-friendly AI Interface (Supports Ollama, OpenAI API, ...)"
     },
     {
       "name": "gpt4all",
@@ -1175,7 +1285,8 @@
       "starsNumeric": 77000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "GPT4All: Run Local LLMs on Any Device. Open-source and available for commercial use."
     },
     {
       "name": "LobeChat",
@@ -1185,7 +1296,8 @@
       "starsNumeric": 75000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "The ultimate space for work and life — to find, build, and collaborate with agent teammates that grow with you. We are taking agent harness to the next level — enabling multi-agent collaboration, effortless agent team design, and introducing agents as the unit of work interaction."
     },
     {
       "name": "AnythingLLM",
@@ -1195,7 +1307,8 @@
       "starsNumeric": 58000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "The all-in-one AI productivity accelerator. On device and privacy first with no annoying setup or configuration."
     },
     {
       "name": "Paperclip",
@@ -1205,7 +1318,8 @@
       "starsNumeric": 58000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Open-source orchestration for zero-human companies"
     },
     {
       "name": "MiroFish",
@@ -1215,7 +1329,8 @@
       "starsNumeric": 57000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "A Simple and Universal Swarm Intelligence Engine, Predicting Anything. 简洁通用的群体智能引擎，预测万物"
     },
     {
       "name": "Flowise",
@@ -1225,7 +1340,8 @@
       "starsNumeric": 52000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Build AI Agents, Visually"
     },
     {
       "name": "Jan",
@@ -1235,7 +1351,8 @@
       "starsNumeric": 42000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Jan is an open source alternative to ChatGPT that runs 100% offline on your computer."
     },
     {
       "name": "LibreChat",
@@ -1245,7 +1362,8 @@
       "starsNumeric": 35000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Enhanced ChatGPT Clone: Features Agents, MCP, DeepSeek, Anthropic, AWS, OpenAI, Responses API, Azure, Groq, o1, GPT-5, Mistral, OpenRouter, Vertex AI, Gemini, Artifacts, AI model switching, message search, Code Interpreter, langchain, DALL-E-3, OpenAPI Actions, Functions, Secure Multi-User Auth, Presets, open-source for self-hosting. Active."
     },
     {
       "name": "Khoj",
@@ -1255,7 +1373,8 @@
       "starsNumeric": 34000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Your AI second brain. Self-hostable. Get answers from the web or your docs. Build custom agents, schedule automations, do deep research. Turn any online or local LLM into your personal, autonomous AI (gpt, claude, gemini, llama, qwen, mistral). Get started - free."
     },
     {
       "name": "Vane (ex-Perplexica)",
@@ -1265,7 +1384,8 @@
       "starsNumeric": 33000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Vane is an AI-powered answering engine."
     },
     {
       "name": "Activepieces",
@@ -1275,7 +1395,8 @@
       "starsNumeric": 21000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "AI Agents & MCPs & AI Workflow Automation • (~400 MCP servers for AI agents) • AI Automation / AI Agent with MCPs • AI Workflows & AI Agents • MCPs for AI Agents"
     },
     {
       "name": "DeepTutor",
@@ -1285,7 +1406,8 @@
       "starsNumeric": 21000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "\"DeepTutor: Agent-Native Personalized Learning Assistant\""
     },
     {
       "name": "Multica",
@@ -1295,7 +1417,8 @@
       "starsNumeric": 20000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "The open-source managed agents platform. Turn coding agents into real teammates — assign tasks, track progress, compound skills."
     },
     {
       "name": "Fincept Terminal",
@@ -1305,7 +1428,8 @@
       "starsNumeric": 13000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "FinceptTerminal is a modern finance application offering advanced market analytics, investment research, and economic data tools, designed for interactive exploration and data-driven decision-making in a user-friendly environment."
     },
     {
       "name": "Rowboat",
@@ -1315,7 +1439,8 @@
       "starsNumeric": 13000,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "Open-source AI coworker, with memory"
     },
     {
       "name": "Feynman",
@@ -1325,7 +1450,8 @@
       "starsNumeric": 5800,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": null
     },
     {
       "name": "agentic-inbox",
@@ -1335,7 +1461,8 @@
       "starsNumeric": 1300,
       "categorySlug": "business",
       "categoryEmoji": "💼",
-      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის"
+      "categoryGeorgian": "მზა AI აგენტები ბიზნესისთვის",
+      "descriptionEn": "A self-hosted email client with an AI agent, running entirely on Cloudflare Workers"
     },
     {
       "name": "RAGFlow",
@@ -1345,7 +1472,8 @@
       "starsNumeric": 78000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "RAGFlow is a leading open-source Retrieval-Augmented Generation (RAG) engine that fuses cutting-edge RAG with Agent capabilities to create a superior context layer for LLMs"
     },
     {
       "name": "mem0",
@@ -1355,7 +1483,8 @@
       "starsNumeric": 53000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Universal memory layer for AI Agents"
     },
     {
       "name": "MemPalace",
@@ -1365,7 +1494,8 @@
       "starsNumeric": 49000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "The best-benchmarked open-source AI memory system. And it's free."
     },
     {
       "name": "LlamaIndex",
@@ -1375,7 +1505,8 @@
       "starsNumeric": 48000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "LlamaIndex is the leading document agent and OCR platform"
     },
     {
       "name": "Milvus",
@@ -1385,7 +1516,8 @@
       "starsNumeric": 43000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Milvus is a high-performance, cloud-native vector database built for scalable vector ANN search"
     },
     {
       "name": "LightRAG",
@@ -1395,7 +1527,8 @@
       "starsNumeric": 34000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "[EMNLP2025] \"LightRAG: Simple and Fast Retrieval-Augmented Generation\""
     },
     {
       "name": "Qdrant",
@@ -1405,7 +1538,8 @@
       "starsNumeric": 30000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Qdrant - High-performance, massive-scale Vector Database and Vector Search Engine for the next generation of AI. Also available in the cloud https://cloud.qdrant.io/"
     },
     {
       "name": "Chroma",
@@ -1415,7 +1549,8 @@
       "starsNumeric": 27000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Data infrastructure for AI"
     },
     {
       "name": "Graphiti",
@@ -1425,7 +1560,8 @@
       "starsNumeric": 25000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Build Real-Time Knowledge Graphs for AI Agents"
     },
     {
       "name": "Letta",
@@ -1435,7 +1571,8 @@
       "starsNumeric": 22000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Letta is the platform for building stateful agents: AI with advanced memory that can learn and self-improve over time."
     },
     {
       "name": "RAG-Anything",
@@ -1445,7 +1582,8 @@
       "starsNumeric": 18000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "\"RAG-Anything: All-in-One RAG Framework\""
     },
     {
       "name": "gbrain",
@@ -1455,7 +1593,8 @@
       "starsNumeric": 10000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Garry's Opinionated OpenClaw/Hermes Agent Brain"
     },
     {
       "name": "Hindsight",
@@ -1465,7 +1604,8 @@
       "starsNumeric": 10000,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Hindsight: Agent Memory That  Learns"
     },
     {
       "name": "Crawl4AI RAG",
@@ -1475,7 +1615,8 @@
       "starsNumeric": 2100,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "Web Crawling and RAG Capabilities for AI Agents and AI Coding Assistants"
     },
     {
       "name": "Prism MCP",
@@ -1485,7 +1626,8 @@
       "starsNumeric": 129,
       "categorySlug": "memory",
       "categoryEmoji": "🧠",
-      "categoryGeorgian": "მეხსიერება და RAG"
+      "categoryGeorgian": "მეხსიერება და RAG",
+      "descriptionEn": "The Mind Palace for AI Agents - HIPAA-hardened Cognitive Architecture with on-device LLM (prism-coder:7b), Hebbian learning, ACT-R spreading activation, adversarial evaluation, persistent memory, multi-agent Hivemind and visual dashboard. Zero API keys required."
     },
     {
       "name": "Ollama",
@@ -1495,7 +1637,8 @@
       "starsNumeric": 169000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Get up and running with Kimi-K2.5, GLM-5, MiniMax, DeepSeek, gpt-oss, Qwen, Gemma and other models."
     },
     {
       "name": "Transformers",
@@ -1505,7 +1648,8 @@
       "starsNumeric": 159000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training. "
     },
     {
       "name": "ComfyUI",
@@ -1515,7 +1659,8 @@
       "starsNumeric": 109000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "The most powerful and modular diffusion model GUI, api and backend with a graph/nodes interface."
     },
     {
       "name": "llama.cpp",
@@ -1525,7 +1670,8 @@
       "starsNumeric": 106000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "LLM inference in C/C++"
     },
     {
       "name": "vLLM",
@@ -1535,7 +1681,8 @@
       "starsNumeric": 77000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "A high-throughput and memory-efficient inference and serving engine for LLMs"
     },
     {
       "name": "Stable Diffusion",
@@ -1545,7 +1692,8 @@
       "starsNumeric": 72000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "A latent text-to-image diffusion model"
     },
     {
       "name": "Unsloth",
@@ -1555,7 +1703,8 @@
       "starsNumeric": 62000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Web UI for training and running open models like Gemma 4, Qwen3.5, DeepSeek, gpt-oss locally."
     },
     {
       "name": "whisper.cpp",
@@ -1565,7 +1714,8 @@
       "starsNumeric": 48000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Port of OpenAI's Whisper model in C/C++"
     },
     {
       "name": "LocalAI",
@@ -1575,7 +1725,8 @@
       "starsNumeric": 45000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "LocalAI is the open-source AI engine. Run any model - LLMs, vision, voice, image, video - on any hardware. No GPU required."
     },
     {
       "name": "Coqui TTS",
@@ -1585,7 +1736,8 @@
       "starsNumeric": 45000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "🐸💬 - a deep learning toolkit for Text-to-Speech, battle-tested in research and production"
     },
     {
       "name": "Bark",
@@ -1595,7 +1747,8 @@
       "starsNumeric": 39000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "🔊 Text-Prompted Generative Audio Model"
     },
     {
       "name": "Diffusers",
@@ -1605,7 +1758,8 @@
       "starsNumeric": 33000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch."
     },
     {
       "name": "SGLang",
@@ -1615,7 +1769,8 @@
       "starsNumeric": 26000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "SGLang is a high-performance serving framework for large language models and multimodal models."
     },
     {
       "name": "FLUX",
@@ -1625,7 +1780,8 @@
       "starsNumeric": 25000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Official inference repo for FLUX.1 models"
     },
     {
       "name": "Google Workspace CLI",
@@ -1635,7 +1791,8 @@
       "starsNumeric": 25000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Google Workspace CLI — one command-line tool for Drive, Gmail, Calendar, Sheets, Docs, Chat, Admin, and more. Dynamically built from Google Discovery Service. Includes AI agent skills."
     },
     {
       "name": "toon",
@@ -1645,7 +1802,8 @@
       "starsNumeric": 23000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "🎒 Token-Oriented Object Notation (TOON) – Compact, human-readable, schema-aware JSON for LLM prompts. Spec, benchmarks, TypeScript SDK."
     },
     {
       "name": "Kronos",
@@ -1655,7 +1813,8 @@
       "starsNumeric": 20000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Kronos: A Foundation Model for the Language of Financial Markets"
     },
     {
       "name": "VoxCPM",
@@ -1665,7 +1824,8 @@
       "starsNumeric": 15000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "VoxCPM2: Tokenizer-Free TTS for Multilingual Speech Generation, Creative Voice Design, and True-to-Life Cloning"
     },
     {
       "name": "HunyuanVideo",
@@ -1675,7 +1835,8 @@
       "starsNumeric": 12000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "HunyuanVideo: A Systematic Framework For Large Video Generation Model"
     },
     {
       "name": "NotebookLM Python",
@@ -1685,7 +1846,8 @@
       "starsNumeric": 11000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Unofficial Python API and agentic skill for Google NotebookLM. Full programmatic access to NotebookLM's features—including capabilities the web UI doesn't expose—via Python, CLI, and AI agents like Claude Code, Codex, and OpenClaw."
     },
     {
       "name": "Hyperframes",
@@ -1695,7 +1857,8 @@
       "starsNumeric": 11000,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Write HTML. Render video. Built for agents."
     },
     {
       "name": "LM Studio",
@@ -1705,7 +1868,8 @@
       "starsNumeric": 4700,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "LM Studio CLI"
     },
     {
       "name": "RealtimeTTS",
@@ -1715,7 +1879,8 @@
       "starsNumeric": 3900,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Converts text to speech in realtime"
     },
     {
       "name": "video-use",
@@ -1725,7 +1890,8 @@
       "starsNumeric": 3800,
       "categorySlug": "infra",
       "categoryEmoji": "⚙️",
-      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები"
+      "categoryGeorgian": "AI ინფრასტრუქტურა და ხელსაწყოები",
+      "descriptionEn": "Edit videos with coding agents"
     },
     {
       "name": "Build Your Own X",
@@ -1735,7 +1901,8 @@
       "starsNumeric": 493000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "Master programming by recreating your favorite technologies from scratch."
     },
     {
       "name": "Public APIs",
@@ -1745,7 +1912,8 @@
       "starsNumeric": 426000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A collective list of free APIs"
     },
     {
       "name": "System Prompts Collection",
@@ -1755,7 +1923,8 @@
       "starsNumeric": 135000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "FULL Augment Code, Claude Code, Cluely, CodeBuddy, Comet, Cursor, Devin AI, Junie, Kiro, Leap.new, Lovable, Manus, NotionAI, Orchids.app, Perplexity, Poke, Qoder, Replit, Same.dev, Trae, Traycer AI, VSCode Agent, Warp.dev, Windsurf, Xcode, Z.ai Code, Dia & v0. (And other Open Sourced) System Prompts, Internal Tools & AI Models"
     },
     {
       "name": "LLMs from Scratch",
@@ -1765,7 +1934,8 @@
       "starsNumeric": 91000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "Implement a ChatGPT-like LLM in PyTorch from scratch, step by step"
     },
     {
       "name": "AutoResearch",
@@ -1775,7 +1945,8 @@
       "starsNumeric": 76000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "AI agents running research on single-GPU nanochat training automatically"
     },
     {
       "name": "DESIGN.md",
@@ -1785,7 +1956,8 @@
       "starsNumeric": 6300,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A format specification for describing a visual identity to coding agents. DESIGN.md gives agents a persistent, structured understanding of a design system."
     },
     {
       "name": "Awesome DESIGN.md",
@@ -1795,7 +1967,8 @@
       "starsNumeric": 64000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A collection of DESIGN.md files inspired by popular brand design systems. Drop one into your project and let coding agents generate a matching UI."
     },
     {
       "name": "Anthropic Cookbook",
@@ -1805,7 +1978,8 @@
       "starsNumeric": 41000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A collection of notebooks/recipes showcasing some fun and effective ways of using Claude."
     },
     {
       "name": "Awesome Claude Code",
@@ -1815,7 +1989,8 @@
       "starsNumeric": 40000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A curated list of awesome skills, hooks, slash-commands, agent orchestrators, applications, and plugins for Claude Code by Anthropic"
     },
     {
       "name": "Claude × HyperFrames Guide",
@@ -1825,7 +2000,8 @@
       "starsNumeric": null,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "Write HTML. Render video. Built for agents."
     },
     {
       "name": "LLM-Maintained Wiki (Karpathy)",
@@ -1835,7 +2011,8 @@
       "starsNumeric": null,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": null
     },
     {
       "name": "Claude How-To",
@@ -1845,7 +2022,8 @@
       "starsNumeric": 28000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A visual, example-driven guide to Claude Code — from basic concepts to advanced agents, with copy-paste templates that bring immediate value."
     },
     {
       "name": "Free LLM API Resources",
@@ -1855,7 +2033,8 @@
       "starsNumeric": 19000,
       "categorySlug": "resources",
       "categoryEmoji": "📚",
-      "categoryGeorgian": "რესურსები და სასწავლო მასალები"
+      "categoryGeorgian": "რესურსები და სასწავლო მასალები",
+      "descriptionEn": "A list of free LLM inference resources accessible via API."
     }
   ]
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aipulsegeorgia/mcp-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aipulsegeorgia/mcp-server",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aipulsegeorgia/mcp-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for the AI Pulse Georgia awesome list — query 179+ curated AI repos from inside Claude Code, Cursor, and other MCP-compatible clients.",
   "type": "module",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "files": [
     "dist",
-    "data",
+    "data/repos.json",
     "README.md",
     "LICENSE"
   ],

--- a/mcp/scripts/build-data.ts
+++ b/mcp/scripts/build-data.ts
@@ -2,9 +2,12 @@
  * Parses the root README.md and emits data/repos.json — the canonical
  * data source for the MCP server. Run on every README change.
  *
+ * Now also enriches each repo with `descriptionEn` from the GitHub repo's
+ * own metadata (cached in data/github-cache.json so we don't re-fetch).
+ *
  * Output: { generated, totalRepos, categories, repos }
  */
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,6 +16,7 @@ const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, "..", "..");
 const README = resolve(ROOT, "README.md");
 const OUT = resolve(__dirname, "..", "data", "repos.json");
+const GH_CACHE = resolve(__dirname, "..", "data", "github-cache.json");
 
 type Category = {
   slug: string;
@@ -39,12 +43,19 @@ type Repo = {
   stars: string;
   starsNumeric: number | null;
   description: string;
+  descriptionEn: string | null;
   categorySlug: string;
   categoryEmoji: string;
   categoryGeorgian: string;
 };
 
-/** "11K" → 11000, "187K" → 187000, "1.5M" → 1500000, "Guide" → null */
+type GhCacheEntry = {
+  description: string | null;
+  fetchedAt: string;
+};
+type GhCache = Record<string, GhCacheEntry>;
+
+/** "11K" → 11000, "187K" → 187000, "Guide" → null */
 function parseStars(raw: string): number | null {
   const trimmed = raw.trim();
   const m = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMkm])?$/);
@@ -56,7 +67,6 @@ function parseStars(raw: string): number | null {
   return Math.round(num);
 }
 
-/** Extract Georgian section heading: "## 🤖 კოდინგ აგენტები" → category */
 function parseHeading(line: string): Category | null {
   const m = line.match(/^##\s+(\p{Emoji_Presentation}|\p{Extended_Pictographic})\s*️?\s+(.+?)\s*$/u);
   if (!m) return null;
@@ -66,7 +76,6 @@ function parseHeading(line: string): Category | null {
   return { ...meta, georgian };
 }
 
-/** Extract repo from a markdown table row: | [name](url) | stars | description | */
 function parseRow(line: string): Pick<Repo, "name" | "url" | "stars" | "description"> | null {
   if (!line.startsWith("| [")) return null;
   const cells = line.split(" | ").map((c, i, arr) => {
@@ -85,10 +94,59 @@ function parseRow(line: string): Pick<Repo, "name" | "url" | "stars" | "descript
   };
 }
 
-function parse(): { repos: Repo[]; categories: Category[] } {
+/** Extract `owner/repo` from a github.com URL. Returns null for non-repo URLs. */
+function parseGithubRepo(url: string): string | null {
+  const m = url.match(/^https?:\/\/github\.com\/([^/]+)\/([^/?#]+)/i);
+  if (!m) return null;
+  const owner = m[1]!;
+  const repo = m[2]!.replace(/\.git$/, "");
+  // Skip non-repo URLs like /blob/, /tree/, /search, /sponsors etc.
+  if (owner === "" || repo === "" || ["search", "marketplace", "topics"].includes(owner.toLowerCase())) return null;
+  return `${owner}/${repo}`;
+}
+
+/** Fetch GitHub repo description via the public API. Uses GITHUB_TOKEN if set for higher rate limits. */
+async function fetchGhDescription(slug: string): Promise<string | null> {
+  const url = `https://api.github.com/repos/${slug}`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "aipulsegeorgia-mcp-build",
+  };
+  const token = process.env["GITHUB_TOKEN"];
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      console.warn(`  ! ${slug}: HTTP ${res.status}`);
+      return null;
+    }
+    const data = (await res.json()) as { description?: string | null };
+    return data.description ?? null;
+  } catch (err) {
+    console.warn(`  ! ${slug}: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+function loadGhCache(): GhCache {
+  if (!existsSync(GH_CACHE)) return {};
+  try {
+    return JSON.parse(readFileSync(GH_CACHE, "utf-8")) as GhCache;
+  } catch {
+    return {};
+  }
+}
+
+function saveGhCache(cache: GhCache): void {
+  mkdirSync(dirname(GH_CACHE), { recursive: true });
+  writeFileSync(GH_CACHE, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+}
+
+function parseReadme(): { repos: Omit<Repo, "descriptionEn">[]; categories: Category[] } {
   const text = readFileSync(README, "utf-8");
   const lines = text.split("\n");
-  const repos: Repo[] = [];
+  const repos: Omit<Repo, "descriptionEn">[] = [];
   const categories: Category[] = [];
   const seen = new Set<string>();
   let current: Category | null = null;
@@ -118,8 +176,45 @@ function parse(): { repos: Repo[]; categories: Category[] } {
   return { repos, categories };
 }
 
-function main(): void {
-  const { repos, categories } = parse();
+async function enrichWithEnglish(repos: Omit<Repo, "descriptionEn">[]): Promise<Repo[]> {
+  const cache = loadGhCache();
+  const skipFetch = process.env["SKIP_GH_FETCH"] === "1";
+  let fetched = 0;
+  let cached = 0;
+  let nonGithub = 0;
+
+  const enriched: Repo[] = [];
+  for (const repo of repos) {
+    const slug = parseGithubRepo(repo.url);
+
+    let descriptionEn: string | null = null;
+    if (!slug) {
+      nonGithub += 1;
+    } else if (cache[slug]) {
+      descriptionEn = cache[slug]!.description;
+      cached += 1;
+    } else if (skipFetch) {
+      descriptionEn = null;
+    } else {
+      descriptionEn = await fetchGhDescription(slug);
+      cache[slug] = { description: descriptionEn, fetchedAt: new Date().toISOString() };
+      fetched += 1;
+      // Be polite to the API
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    enriched.push({ ...repo, descriptionEn });
+  }
+
+  if (fetched > 0) saveGhCache(cache);
+  // eslint-disable-next-line no-console
+  console.log(`  fetched=${fetched}, cached=${cached}, non-github=${nonGithub}`);
+  return enriched;
+}
+
+async function main(): Promise<void> {
+  const { repos: parsed, categories } = parseReadme();
+  const repos = await enrichWithEnglish(parsed);
   const output = {
     generated: new Date().toISOString(),
     totalRepos: repos.length,
@@ -131,8 +226,15 @@ function main(): void {
   };
   mkdirSync(dirname(OUT), { recursive: true });
   writeFileSync(OUT, JSON.stringify(output, null, 2) + "\n", "utf-8");
+  const withEn = repos.filter((r) => r.descriptionEn !== null).length;
   // eslint-disable-next-line no-console
-  console.log(`Wrote ${repos.length} repos across ${categories.length} categories → ${OUT}`);
+  console.log(
+    `Wrote ${repos.length} repos across ${categories.length} categories → ${OUT}\n` +
+      `  ${withEn}/${repos.length} have English descriptions (${Math.round((withEn / repos.length) * 100)}%)`,
+  );
 }
 
-main();
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/data.ts
+++ b/mcp/src/data.ts
@@ -14,7 +14,10 @@ export type Repo = {
   url: string;
   stars: string;
   starsNumeric: number | null;
+  /** Editorial Georgian description (rich, 3-5 sentences) — always present. */
   description: string;
+  /** Short English description from GitHub repo metadata. May be null for non-github URLs. */
+  descriptionEn: string | null;
   categorySlug: string;
   categoryEmoji: string;
   categoryGeorgian: string;

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -5,6 +5,9 @@
  * Exposes the curated awesome-ai-pulse-georgia repo collection (179+ repos
  * across 9 categories) as MCP tools. Designed for stdio transport — usable
  * from Claude Code, Cursor, Codex, and any other MCP-compatible client.
+ *
+ * v0.2 — bilingual: every result includes editorial Georgian + GitHub-sourced
+ * English descriptions. Use the `lang` parameter to control which is returned.
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -15,20 +18,37 @@ const collection = loadCollection();
 
 const server = new McpServer({
   name: "aipulsegeorgia-mcp",
-  version: "0.1.0",
+  version: "0.2.0",
 });
 
 const categorySlugs = collection.categories.map((c) => c.slug) as [string, ...string[]];
 const CategoryEnum = z.enum(categorySlugs);
+const LangEnum = z.enum(["en", "ka", "both"]).default("en");
 
 /** Strip markdown links from descriptions for cleaner LLM input. */
 function clean(desc: string): string {
   return desc.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1").replace(/\s+/g, " ").trim();
 }
 
-function summarize(r: Repo): string {
+/**
+ * Pick the description to surface based on the lang preference.
+ * - "en": prefer English; fall back to Georgian if no English available.
+ * - "ka": always Georgian (the editorial original).
+ * - "both": return an object with both fields.
+ */
+function pickDescription(r: Repo, lang: "en" | "ka" | "both"): string | { en: string | null; ka: string } {
+  const ka = clean(r.description);
+  const en = r.descriptionEn ? clean(r.descriptionEn) : null;
+  if (lang === "ka") return ka;
+  if (lang === "both") return { en, ka };
+  return en ?? ka;
+}
+
+function summarize(r: Repo, lang: "en" | "ka" | "both"): string {
   const stars = r.starsNumeric !== null ? `${r.stars} ⭐` : r.stars;
-  return `${r.name} (${stars}) — ${r.url}\n  ${clean(r.description)}\n  Category: ${r.categoryEmoji} ${r.categoryGeorgian}`;
+  const desc = pickDescription(r, lang);
+  const descText = typeof desc === "string" ? desc : `EN: ${desc.en ?? "(none)"}\n  KA: ${desc.ka}`;
+  return `${r.name} (${stars}) — ${r.url}\n  ${descText}\n  Category: ${r.categoryEmoji} ${r.categoryGeorgian}`;
 }
 
 function jsonResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
@@ -53,14 +73,15 @@ server.tool(
 
 server.tool(
   "list_repos",
-  "List repos, optionally filtered by category and sorted. Returns paginated results.",
+  "List repos, optionally filtered by category and sorted. Returns paginated results. Set lang='en' (default) for English descriptions sourced from GitHub, 'ka' for the editorial Georgian description, or 'both' for both.",
   {
     category: CategoryEnum.optional().describe("Filter by category slug (see list_categories)"),
     sortBy: z.enum(["stars", "name"]).default("stars").describe("Sort order; 'stars' returns highest-starred first"),
     limit: z.number().int().min(1).max(100).default(20),
     offset: z.number().int().min(0).default(0),
+    lang: LangEnum.describe("Description language: 'en' (default, English from GitHub), 'ka' (editorial Georgian), 'both'"),
   },
-  async ({ category, sortBy, limit, offset }) => {
+  async ({ category, sortBy, limit, offset, lang }) => {
     let filtered = category
       ? collection.repos.filter((r) => r.categorySlug === category)
       : collection.repos;
@@ -76,13 +97,14 @@ server.tool(
       offset,
       limit,
       hasMore: offset + limit < filtered.length,
+      lang,
       repos: page.map((r) => ({
         name: r.name,
         url: r.url,
         stars: r.stars,
         starsNumeric: r.starsNumeric,
         category: r.categorySlug,
-        description: clean(r.description),
+        description: pickDescription(r, lang),
       })),
     });
   },
@@ -90,20 +112,21 @@ server.tool(
 
 server.tool(
   "search_repos",
-  "Full-text search across name and description. Case-insensitive. Use for queries like 'free claude code', 'browser automation', 'rag'.",
+  "Full-text search across name + Georgian description + English description. Case-insensitive. Use for queries like 'free claude code', 'browser automation', 'rag'.",
   {
     query: z.string().min(2).describe("Search query — at least 2 characters"),
     category: CategoryEnum.optional().describe("Optionally narrow to a single category"),
     limit: z.number().int().min(1).max(50).default(10),
+    lang: LangEnum.describe("Description language to return: 'en' (default), 'ka', or 'both'"),
   },
-  async ({ query, category, limit }) => {
+  async ({ query, category, limit, lang }) => {
     const q = query.toLowerCase();
     const tokens = q.split(/\s+/).filter(Boolean);
 
     const scored = collection.repos
       .filter((r) => !category || r.categorySlug === category)
       .map((r) => {
-        const haystack = `${r.name} ${r.description}`.toLowerCase();
+        const haystack = `${r.name} ${r.description} ${r.descriptionEn ?? ""}`.toLowerCase();
         const score = tokens.reduce((acc, t) => acc + (haystack.includes(t) ? 1 : 0), 0);
         const nameMatch = r.name.toLowerCase().includes(q) ? 5 : 0;
         return { repo: r, score: score + nameMatch };
@@ -118,13 +141,14 @@ server.tool(
     return jsonResult({
       query,
       matched: scored.length,
+      lang,
       repos: scored.map((s) => ({
         name: s.repo.name,
         url: s.repo.url,
         stars: s.repo.stars,
         category: s.repo.categorySlug,
         score: s.score,
-        description: clean(s.repo.description),
+        description: pickDescription(s.repo, lang),
       })),
     });
   },
@@ -135,21 +159,22 @@ server.tool(
   "Get full details for a single repo by name (case-insensitive, supports partial match).",
   {
     name: z.string().min(2).describe("Repo name, e.g. 'Claude Code', 'free-claude-code', 'aider'"),
+    lang: LangEnum.describe("Description language: 'en' (default), 'ka', or 'both'"),
   },
-  async ({ name }) => {
+  async ({ name, lang }) => {
     const q = name.toLowerCase();
     const exact = collection.repos.find((r) => r.name.toLowerCase() === q);
     const partial = exact ?? collection.repos.find((r) => r.name.toLowerCase().includes(q));
     if (!partial) {
       return textResult(`No repo found matching '${name}'. Try search_repos for fuzzy matching.`);
     }
-    return textResult(summarize(partial));
+    return textResult(summarize(partial, lang));
   },
 );
 
 server.tool(
   "stats",
-  "Collection-level stats: total count, top repos by stars, last generated time.",
+  "Collection-level stats: total count, top repos by stars, last generated time, English-coverage rate.",
   {},
   async () => {
     const top = [...collection.repos]
@@ -157,10 +182,12 @@ server.tool(
       .sort((a, b) => (b.starsNumeric ?? 0) - (a.starsNumeric ?? 0))
       .slice(0, 10)
       .map((r) => ({ name: r.name, stars: r.stars, url: r.url, category: r.categorySlug }));
+    const withEn = collection.repos.filter((r) => r.descriptionEn !== null).length;
     return jsonResult({
       totalRepos: collection.totalRepos,
       categories: collection.categories.length,
       generated: collection.generated,
+      englishCoverage: { total: collection.totalRepos, withEnglish: withEn, pct: Math.round((withEn / collection.totalRepos) * 100) },
       top10ByStars: top,
     });
   },


### PR DESCRIPTION
## Summary

v0.2.0 of the AI Pulse Georgia MCP server adds **bilingual support** — every tool now accepts a `lang` parameter (`en` default, `ka`, or `both`).

## What changed

- **Bilingual API** — every result includes editorial Georgian + GitHub-sourced English descriptions
- **97% English coverage** — 173/179 repos have English descriptions (auto-fetched from each repo's GitHub `description` field, cached in `data/github-cache.json`)
- **Better search** — `search_repos` now searches across both languages (queries like "browser automation" match repos whose Georgian description doesn't include those exact words)
- **Default lang='en'** for global audience reach; explicit `lang:'ka'` returns the editorial Georgian, `lang:'both'` returns both

## Architecture

- `scripts/build-data.ts` enhanced — fetches GitHub repo metadata via REST API, caches in `data/github-cache.json` (committed, incremental)
- `data/github-cache.json` is build-time only — excluded from npm tarball via explicit `files: ["data/repos.json"]` allowlist
- CI workflows pass `GITHUB_TOKEN` to the build step for higher rate limits

## Verified locally

- `npm run build:data` — fetched 177, cached 1, non-github 1 → **173/179 (97%) have English**
- `npm run build` — 6.94 KB bundle (was 5.75 in v0.1.x)
- `npm run smoke` — all 11 assertions pass
- `get_repo({name:'free-claude-code', lang:'both'})` returns EN + KA correctly

## Auto-publish flow

When this PR merges to main, the existing `mcp-publish.yml` workflow detects the version bump in `mcp/package.json` (0.1.1 → 0.2.0) and publishes automatically to npm under `@aipulsegeorgia/mcp-server@0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)