### PR TITLE
fix(ci): remove [skip ci] from data-sync auto-commit

### DIFF
--- a/.github/workflows/mcp-data-sync.yml
+++ b/.github/workflows/mcp-data-sync.yml
@@ -65,6 +65,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add mcp/data/repos.json mcp/package.json mcp/package-lock.json
-          git commit -m "chore(mcp): sync data + bump patch version [skip ci]"
+          git add mcp/data/repos.json mcp/package.json mcp/package-lock.json mcp/data/github-cache.json
+          git commit -m "chore(mcp): sync data + bump patch version"
           git push
+        # Note: no [skip ci] — we WANT mcp-publish.yml to trigger on the
+        # mcp/package.json change. The data-sync workflow itself won't loop
+        # because its paths filter (README.md, scripts/build-data.ts) doesn't
+        # match this commit's changes.


### PR DESCRIPTION
Removes [skip ci] flag that was blocking the publish workflow from triggering after auto-bumps. Loop risk is negligible because data-sync's paths filter excludes the files it commits.