### PR TITLE
feat(mcp): add aipulse CLI — terminal access to the collection

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # AI Pulse Georgia — MCP Server
 
-Query the [awesome-ai-pulse-georgia](https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia) curated collection (213+ AI repos across 9 categories) directly from inside Claude Code, Cursor, Codex, Claude.ai, or any other [Model Context Protocol](https://modelcontextprotocol.io)–compatible client.
+Query the [awesome-ai-pulse-georgia](https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia) curated collection (250+ AI repos across 14 categories) directly from inside Claude Code, Cursor, Codex, Claude.ai, or any other [Model Context Protocol](https://modelcontextprotocol.io)–compatible client — or straight from your terminal with the bundled `aipulse` **CLI**.
 
 Instead of opening GitHub and scrolling through a README, ask your AI assistant:
 
@@ -66,7 +66,7 @@ Then point your client at the absolute path of `dist/index.js` instead of `npx`.
 
 | Tool | Purpose | Example call |
 |------|---------|--------------|
-| `list_categories` | Show all 9 categories with repo counts | — |
+| `list_categories` | Show all categories with repo counts | — |
 | `list_repos` | Browse by category, sort by stars or name, paginate | `{"category":"coding","limit":10,"lang":"en"}` |
 | `search_repos` | Full-text search across name + descriptions (EN+KA) | `{"query":"browser automation","lang":"both"}` |
 | `get_repo` | Fetch full details for a single repo | `{"name":"free-claude-code","lang":"en"}` |
@@ -76,7 +76,30 @@ All tools accept `lang: "en" | "ka" | "both"` (default `"en"`). English descript
 
 ### Categories
 
-`coding` (🤖) · `plugins` (⚡) · `mcp` (🔌) · `scraping` (🕷️) · `frameworks` (🧬) · `business` (💼) · `memory` (🧠) · `infra` (⚙️) · `resources` (📚)
+`coding` (🤖) · `plugins` (⚡) · `design` (🎨) · `mcp` (🔌) · `scraping` (🕷️) · `frameworks` (🧬) · `workflow` (🔁) · `business` (💼) · `finance` (💰) · `memory` (🧠) · `codeintel` (🔍) · `infra` (⚙️) · `media` (🎬) · `resources` (📚)
+
+---
+
+## CLI (terminal access)
+
+The same collection is queryable straight from your terminal — zero MCP client needed. The package ships a second binary, `aipulse`:
+
+```bash
+# via npx (no install)
+npx -p @aipulsegeorgia/mcp-server aipulse search "rag memory"
+
+# or after a global install / local build
+aipulse categories
+aipulse list --category coding --limit 10
+aipulse search "browser automation" --lang both
+aipulse get aider
+aipulse stats
+```
+
+Commands: `categories`, `list`, `search <query>`, `get <name>`, `stats`.
+Options: `-c/--category <slug>`, `-n/--limit <N>`, `--offset <N>`, `-s/--sort stars|name`, `-l/--lang en|ka|both`, `--json` (machine-readable output).
+
+The CLI shares its query logic (`src/query.ts`) with the MCP server, so results are identical across both surfaces.
 
 ---
 
@@ -95,9 +118,10 @@ When the README is updated (new repo added, stars refreshed), running `npm run b
 | Command | Effect |
 |---------|--------|
 | `npm run build:data` | Re-parse README → `data/repos.json` |
-| `npm run build` | Build data + compile bundle to `dist/` |
-| `npm run dev` | Run from source via `tsx` (no build step) |
-| `npm start` | Run the compiled bundle |
+| `npm run build` | Build data + compile MCP + CLI bundles to `dist/` |
+| `npm run dev` | Run the MCP server from source via `tsx` |
+| `npm run cli` | Run the CLI from source, e.g. `npm run cli -- search rag` |
+| `npm start` | Run the compiled MCP bundle |
 
 ---
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@aipulsegeorgia/mcp-server",
   "version": "0.2.17",
-  "description": "MCP server for the AI Pulse Georgia awesome list — query 213+ curated AI repos from inside Claude Code, Cursor, and other MCP-compatible clients.",
+  "description": "MCP server + CLI for the AI Pulse Georgia awesome list — query 250+ curated AI repos from inside Claude Code, Cursor, other MCP clients, or straight from your terminal.",
   "type": "module",
   "bin": {
-    "aipulsegeorgia-mcp": "dist/index.js"
+    "aipulsegeorgia-mcp": "dist/index.js",
+    "aipulse": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -14,8 +15,9 @@
   ],
   "scripts": {
     "build:data": "tsx scripts/build-data.ts",
-    "build": "npm run build:data && tsup src/index.ts --format esm --target node20 --clean --shims",
+    "build": "npm run build:data && tsup src/index.ts src/cli.ts --format esm --target node20 --clean --shims",
     "dev": "tsx src/index.ts",
+    "cli": "tsx src/cli.ts",
     "start": "node dist/index.js",
     "smoke": "tsx scripts/smoke-test.ts",
     "prepublishOnly": "npm run build && npm run smoke"

--- a/mcp/scripts/smoke-test.ts
+++ b/mcp/scripts/smoke-test.ts
@@ -123,6 +123,27 @@ async function run(): Promise<void> {
   const searchParsed = searchContent ? (JSON.parse(searchContent) as { matched: number }) : null;
   expect(searchParsed !== null && searchParsed.matched > 0, `search 'claude' returns matches (got ${searchParsed?.matched})`);
 
+  // --- CLI check (same data, terminal surface) ---
+  const cliBundle = resolve(__dirname, "..", "dist", "cli.js");
+  let cliOut = "";
+  if (existsSync(cliBundle)) {
+    const cli = spawn("node", [cliBundle, "stats", "--json"], { stdio: ["ignore", "pipe", "pipe"] });
+    cli.stdout.on("data", (chunk: Buffer) => {
+      cliOut += chunk.toString("utf-8");
+    });
+    await new Promise((r) => cli.once("exit", r));
+  }
+  let cliStats: { totalRepos?: number } | null = null;
+  try {
+    cliStats = JSON.parse(cliOut) as { totalRepos?: number };
+  } catch {
+    cliStats = null;
+  }
+  expect(
+    cliStats !== null && (cliStats.totalRepos ?? 0) > 0,
+    `CLI 'stats --json' returns totalRepos > 0 (got ${cliStats?.totalRepos})`,
+  );
+
   if (process.exitCode === 1) {
     console.error("\n✗ Smoke test FAILED");
     process.exit(1);

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * AI Pulse Georgia CLI
+ *
+ * Terminal access to the same curated repo collection the MCP server exposes.
+ * Reuses the shared query logic in query.ts so results match the MCP exactly.
+ *
+ * Usage:
+ *   aipulse categories
+ *   aipulse list [--category <slug>] [--sort stars|name] [--limit N] [--offset N] [--lang en|ka|both]
+ *   aipulse search <query...> [--category <slug>] [--limit N] [--lang en|ka|both]
+ *   aipulse get <name...> [--lang en|ka|both]
+ *   aipulse stats
+ * Global flag: --json (machine-readable output)
+ */
+import { loadCollection } from "./data.js";
+import {
+  getRepo,
+  getStats,
+  listRepos,
+  pickDescription,
+  searchRepos,
+  summarizeRepo,
+  type Lang,
+} from "./query.js";
+
+type Parsed = { _: string[]; flags: Record<string, string | boolean> };
+
+function parseArgs(argv: string[]): Parsed {
+  const aliases: Record<string, string> = {
+    c: "category",
+    n: "limit",
+    s: "sort",
+    l: "lang",
+    h: "help",
+  };
+  const valueFlags = new Set(["category", "limit", "offset", "sort", "lang"]);
+  const _: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a.startsWith("--") || a.startsWith("-")) {
+      let key = a.replace(/^-+/, "");
+      if (aliases[key]) key = aliases[key];
+      if (valueFlags.has(key)) {
+        flags[key] = argv[++i] ?? "";
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      _.push(a);
+    }
+  }
+  return { _, flags };
+}
+
+function asLang(v: unknown): Lang {
+  return v === "ka" || v === "both" ? v : "en";
+}
+
+function descText(d: string | { en: string | null; ka: string }): string {
+  if (typeof d === "string") return d;
+  return `EN: ${d.en ?? "(none)"} | KA: ${d.ka}`;
+}
+
+function printRepoLine(r: {
+  name: string;
+  url: string;
+  stars: string;
+  category: string;
+  description: string | { en: string | null; ka: string };
+}): void {
+  console.log(`★ ${r.stars.padEnd(5)} ${r.name}  [${r.category}]`);
+  console.log(`   ${descText(r.description)}`);
+  console.log(`   ${r.url}\n`);
+}
+
+function help(): void {
+  console.log(`AI Pulse Georgia — curated AI/agentic repo collection (CLI)
+
+Usage:
+  aipulse categories                       List all categories with counts
+  aipulse list [opts]                      List repos (paginated)
+  aipulse search <query...> [opts]         Full-text search
+  aipulse get <name...> [opts]             Show one repo's details
+  aipulse stats                            Collection statistics
+
+Options:
+  -c, --category <slug>   Filter by category slug (see 'categories')
+  -n, --limit <N>         Max results (list: 20, search: 10)
+      --offset <N>        Pagination offset (list)
+  -s, --sort <stars|name> Sort order for list (default: stars)
+  -l, --lang <en|ka|both> Description language (default: en)
+      --json              Machine-readable JSON output
+
+Examples:
+  aipulse search "rag memory" --lang both
+  aipulse list -c coding -n 10
+  aipulse get aider`);
+}
+
+function main(): void {
+  const { _, flags } = parseArgs(process.argv.slice(2));
+  const cmd = _[0] ?? (flags.help ? "help" : "help");
+  const json = flags.json === true;
+  const lang = asLang(flags.lang);
+  const collection = loadCollection();
+
+  switch (cmd) {
+    case "categories":
+    case "cats": {
+      if (json) {
+        console.log(JSON.stringify({ totalRepos: collection.totalRepos, categories: collection.categories }, null, 2));
+        return;
+      }
+      console.log(`${collection.totalRepos} repos across ${collection.categories.length} categories:\n`);
+      for (const c of collection.categories) {
+        console.log(`  ${c.emoji} ${c.english.padEnd(34)} ${String(c.count).padStart(3)}  (${c.slug})`);
+      }
+      return;
+    }
+    case "list":
+    case "ls": {
+      const category = typeof flags.category === "string" ? flags.category : undefined;
+      const sortBy = flags.sort === "name" ? "name" : "stars";
+      const limit = Number(flags.limit) || 20;
+      const offset = Number(flags.offset) || 0;
+      const res = listRepos(collection, { category, sortBy, limit, offset });
+      const repos = res.items.map((r) => ({
+        name: r.name, url: r.url, stars: r.stars, category: r.categorySlug,
+        description: pickDescription(r, lang),
+      }));
+      if (json) {
+        console.log(JSON.stringify({ total: res.total, offset: res.offset, limit: res.limit, hasMore: res.hasMore, repos }, null, 2));
+        return;
+      }
+      console.log(`${res.total} repos${category ? ` in '${category}'` : ""} — showing ${repos.length} (offset ${offset})\n`);
+      repos.forEach(printRepoLine);
+      if (res.hasMore) console.log(`… more available — add: --offset ${offset + limit}`);
+      return;
+    }
+    case "search":
+    case "s": {
+      const query = _.slice(1).join(" ");
+      if (query.length < 2) {
+        console.error("search needs a query of at least 2 characters. e.g. aipulse search rag");
+        process.exitCode = 1;
+        return;
+      }
+      const category = typeof flags.category === "string" ? flags.category : undefined;
+      const limit = Number(flags.limit) || 10;
+      const scored = searchRepos(collection, { query, category, limit });
+      const repos = scored.map((s) => ({
+        name: s.repo.name, url: s.repo.url, stars: s.repo.stars, category: s.repo.categorySlug,
+        score: s.score, description: pickDescription(s.repo, lang),
+      }));
+      if (json) {
+        console.log(JSON.stringify({ query, matched: repos.length, repos }, null, 2));
+        return;
+      }
+      console.log(`"${query}" — ${repos.length} match${repos.length === 1 ? "" : "es"}\n`);
+      repos.forEach(printRepoLine);
+      return;
+    }
+    case "get":
+    case "show": {
+      const name = _.slice(1).join(" ");
+      if (name.length < 2) {
+        console.error("get needs a repo name. e.g. aipulse get aider");
+        process.exitCode = 1;
+        return;
+      }
+      const repo = getRepo(collection, name);
+      if (!repo) {
+        console.error(`No repo found matching '${name}'. Try: aipulse search ${name}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (json) {
+        console.log(JSON.stringify({ ...repo, description: pickDescription(repo, lang) }, null, 2));
+        return;
+      }
+      console.log(summarizeRepo(repo, lang));
+      return;
+    }
+    case "stats": {
+      const s = getStats(collection);
+      if (json) {
+        console.log(JSON.stringify(s, null, 2));
+        return;
+      }
+      console.log(`AI Pulse Georgia collection`);
+      console.log(`  Repos:      ${s.totalRepos}`);
+      console.log(`  Categories: ${s.categories}`);
+      console.log(`  English:    ${s.englishCoverage.withEnglish}/${s.englishCoverage.total} (${s.englishCoverage.pct}%)`);
+      console.log(`  Generated:  ${s.generated}`);
+      console.log(`\n  Top 10 by stars:`);
+      s.top10ByStars.forEach((r, i) => console.log(`    ${String(i + 1).padStart(2)}. ${r.stars.padEnd(6)} ${r.name}  [${r.category}]`));
+      return;
+    }
+    case "help":
+    default:
+      help();
+      return;
+  }
+}
+
+main();

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -8,11 +8,21 @@
  *
  * v0.2 — bilingual: every result includes editorial Georgian + GitHub-sourced
  * English descriptions. Use the `lang` parameter to control which is returned.
+ *
+ * Shared query logic lives in query.ts (also used by the CLI in cli.ts).
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { loadCollection, type Repo } from "./data.js";
+import { loadCollection } from "./data.js";
+import {
+  getRepo,
+  getStats,
+  listRepos,
+  pickDescription,
+  searchRepos,
+  summarizeRepo,
+} from "./query.js";
 
 const collection = loadCollection();
 
@@ -24,32 +34,6 @@ const server = new McpServer({
 const categorySlugs = collection.categories.map((c) => c.slug) as [string, ...string[]];
 const CategoryEnum = z.enum(categorySlugs);
 const LangEnum = z.enum(["en", "ka", "both"]).default("en");
-
-/** Strip markdown links from descriptions for cleaner LLM input. */
-function clean(desc: string): string {
-  return desc.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1").replace(/\s+/g, " ").trim();
-}
-
-/**
- * Pick the description to surface based on the lang preference.
- * - "en": prefer English; fall back to Georgian if no English available.
- * - "ka": always Georgian (the editorial original).
- * - "both": return an object with both fields.
- */
-function pickDescription(r: Repo, lang: "en" | "ka" | "both"): string | { en: string | null; ka: string } {
-  const ka = clean(r.description);
-  const en = r.descriptionEn ? clean(r.descriptionEn) : null;
-  if (lang === "ka") return ka;
-  if (lang === "both") return { en, ka };
-  return en ?? ka;
-}
-
-function summarize(r: Repo, lang: "en" | "ka" | "both"): string {
-  const stars = r.starsNumeric !== null ? `${r.stars} ⭐` : r.stars;
-  const desc = pickDescription(r, lang);
-  const descText = typeof desc === "string" ? desc : `EN: ${desc.en ?? "(none)"}\n  KA: ${desc.ka}`;
-  return `${r.name} (${stars}) — ${r.url}\n  ${descText}\n  Category: ${r.categoryEmoji} ${r.categoryGeorgian}`;
-}
 
 function jsonResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
   return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
@@ -65,10 +49,11 @@ server.tool(
   "list_categories",
   "List all categories with repo counts. Use this first to understand the collection's structure.",
   {},
-  async () => jsonResult({
-    totalRepos: collection.totalRepos,
-    categories: collection.categories,
-  }),
+  async () =>
+    jsonResult({
+      totalRepos: collection.totalRepos,
+      categories: collection.categories,
+    }),
 );
 
 server.tool(
@@ -82,23 +67,14 @@ server.tool(
     lang: LangEnum.describe("Description language: 'en' (default, English from GitHub), 'ka' (editorial Georgian), 'both'"),
   },
   async ({ category, sortBy, limit, offset, lang }) => {
-    let filtered = category
-      ? collection.repos.filter((r) => r.categorySlug === category)
-      : collection.repos;
-
-    filtered = [...filtered].sort((a, b) => {
-      if (sortBy === "name") return a.name.localeCompare(b.name);
-      return (b.starsNumeric ?? -1) - (a.starsNumeric ?? -1);
-    });
-
-    const page = filtered.slice(offset, offset + limit);
+    const { total, hasMore, items } = listRepos(collection, { category, sortBy, limit, offset });
     return jsonResult({
-      total: filtered.length,
+      total,
       offset,
       limit,
-      hasMore: offset + limit < filtered.length,
+      hasMore,
       lang,
-      repos: page.map((r) => ({
+      repos: items.map((r) => ({
         name: r.name,
         url: r.url,
         stars: r.stars,
@@ -120,24 +96,7 @@ server.tool(
     lang: LangEnum.describe("Description language to return: 'en' (default), 'ka', or 'both'"),
   },
   async ({ query, category, limit, lang }) => {
-    const q = query.toLowerCase();
-    const tokens = q.split(/\s+/).filter(Boolean);
-
-    const scored = collection.repos
-      .filter((r) => !category || r.categorySlug === category)
-      .map((r) => {
-        const haystack = `${r.name} ${r.description} ${r.descriptionEn ?? ""}`.toLowerCase();
-        const score = tokens.reduce((acc, t) => acc + (haystack.includes(t) ? 1 : 0), 0);
-        const nameMatch = r.name.toLowerCase().includes(q) ? 5 : 0;
-        return { repo: r, score: score + nameMatch };
-      })
-      .filter((s) => s.score > 0)
-      .sort((a, b) => {
-        if (b.score !== a.score) return b.score - a.score;
-        return (b.repo.starsNumeric ?? -1) - (a.repo.starsNumeric ?? -1);
-      })
-      .slice(0, limit);
-
+    const scored = searchRepos(collection, { query, category, limit });
     return jsonResult({
       query,
       matched: scored.length,
@@ -162,13 +121,11 @@ server.tool(
     lang: LangEnum.describe("Description language: 'en' (default), 'ka', or 'both'"),
   },
   async ({ name, lang }) => {
-    const q = name.toLowerCase();
-    const exact = collection.repos.find((r) => r.name.toLowerCase() === q);
-    const partial = exact ?? collection.repos.find((r) => r.name.toLowerCase().includes(q));
-    if (!partial) {
+    const repo = getRepo(collection, name);
+    if (!repo) {
       return textResult(`No repo found matching '${name}'. Try search_repos for fuzzy matching.`);
     }
-    return textResult(summarize(partial, lang));
+    return textResult(summarizeRepo(repo, lang));
   },
 );
 
@@ -176,21 +133,7 @@ server.tool(
   "stats",
   "Collection-level stats: total count, top repos by stars, last generated time, English-coverage rate.",
   {},
-  async () => {
-    const top = [...collection.repos]
-      .filter((r) => r.starsNumeric !== null)
-      .sort((a, b) => (b.starsNumeric ?? 0) - (a.starsNumeric ?? 0))
-      .slice(0, 10)
-      .map((r) => ({ name: r.name, stars: r.stars, url: r.url, category: r.categorySlug }));
-    const withEn = collection.repos.filter((r) => r.descriptionEn !== null).length;
-    return jsonResult({
-      totalRepos: collection.totalRepos,
-      categories: collection.categories.length,
-      generated: collection.generated,
-      englishCoverage: { total: collection.totalRepos, withEnglish: withEn, pct: Math.round((withEn / collection.totalRepos) * 100) },
-      top10ByStars: top,
-    });
-  },
+  async () => jsonResult(getStats(collection)),
 );
 
 // --- Boot ---

--- a/mcp/src/query.ts
+++ b/mcp/src/query.ts
@@ -1,0 +1,132 @@
+/**
+ * Shared query logic over the repo collection.
+ * Used by BOTH the MCP server (src/index.ts) and the CLI (src/cli.ts)
+ * so search/list/get behaviour stays identical across both surfaces.
+ */
+import type { Collection, Repo } from "./data.js";
+
+export type Lang = "en" | "ka" | "both";
+
+/** Strip markdown links from descriptions for cleaner output. */
+export function clean(desc: string): string {
+  return desc.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1").replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Pick the description to surface based on the lang preference.
+ * - "en": prefer English; fall back to Georgian if no English available.
+ * - "ka": always Georgian (the editorial original).
+ * - "both": return an object with both fields.
+ */
+export function pickDescription(
+  r: Repo,
+  lang: Lang,
+): string | { en: string | null; ka: string } {
+  const ka = clean(r.description);
+  const en = r.descriptionEn ? clean(r.descriptionEn) : null;
+  if (lang === "ka") return ka;
+  if (lang === "both") return { en, ka };
+  return en ?? ka;
+}
+
+/** One-line human-readable summary of a repo. */
+export function summarizeRepo(r: Repo, lang: Lang): string {
+  const stars = r.starsNumeric !== null ? `${r.stars} ⭐` : r.stars;
+  const desc = pickDescription(r, lang);
+  const descText =
+    typeof desc === "string" ? desc : `EN: ${desc.en ?? "(none)"}\n  KA: ${desc.ka}`;
+  return `${r.name} (${stars}) — ${r.url}\n  ${descText}\n  Category: ${r.categoryEmoji} ${r.categoryGeorgian}`;
+}
+
+export type ListOpts = {
+  category?: string;
+  sortBy?: "stars" | "name";
+  limit?: number;
+  offset?: number;
+};
+
+export type ListResult = {
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+  items: Repo[];
+};
+
+export function listRepos(c: Collection, opts: ListOpts = {}): ListResult {
+  const { category, sortBy = "stars", limit = 20, offset = 0 } = opts;
+  let filtered = category
+    ? c.repos.filter((r) => r.categorySlug === category)
+    : c.repos;
+  filtered = [...filtered].sort((a, b) => {
+    if (sortBy === "name") return a.name.localeCompare(b.name);
+    return (b.starsNumeric ?? -1) - (a.starsNumeric ?? -1);
+  });
+  return {
+    total: filtered.length,
+    offset,
+    limit,
+    hasMore: offset + limit < filtered.length,
+    items: filtered.slice(offset, offset + limit),
+  };
+}
+
+export type Scored = { repo: Repo; score: number };
+
+export function searchRepos(
+  c: Collection,
+  opts: { query: string; category?: string; limit?: number },
+): Scored[] {
+  const { query, category, limit = 10 } = opts;
+  const q = query.toLowerCase();
+  const tokens = q.split(/\s+/).filter(Boolean);
+  return c.repos
+    .filter((r) => !category || r.categorySlug === category)
+    .map((r) => {
+      const haystack = `${r.name} ${r.description} ${r.descriptionEn ?? ""}`.toLowerCase();
+      const score = tokens.reduce((acc, t) => acc + (haystack.includes(t) ? 1 : 0), 0);
+      const nameMatch = r.name.toLowerCase().includes(q) ? 5 : 0;
+      return { repo: r, score: score + nameMatch };
+    })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return (b.repo.starsNumeric ?? -1) - (a.repo.starsNumeric ?? -1);
+    })
+    .slice(0, limit);
+}
+
+/** Find a repo by name — exact match first, then partial (case-insensitive). */
+export function getRepo(c: Collection, name: string): Repo | null {
+  const q = name.toLowerCase();
+  const exact = c.repos.find((r) => r.name.toLowerCase() === q);
+  return exact ?? c.repos.find((r) => r.name.toLowerCase().includes(q)) ?? null;
+}
+
+export type Stats = {
+  totalRepos: number;
+  categories: number;
+  generated: string;
+  englishCoverage: { total: number; withEnglish: number; pct: number };
+  top10ByStars: Array<{ name: string; stars: string; url: string; category: string }>;
+};
+
+export function getStats(c: Collection): Stats {
+  const top = [...c.repos]
+    .filter((r) => r.starsNumeric !== null)
+    .sort((a, b) => (b.starsNumeric ?? 0) - (a.starsNumeric ?? 0))
+    .slice(0, 10)
+    .map((r) => ({ name: r.name, stars: r.stars, url: r.url, category: r.categorySlug }));
+  const withEn = c.repos.filter((r) => r.descriptionEn !== null).length;
+  return {
+    totalRepos: c.totalRepos,
+    categories: c.categories.length,
+    generated: c.generated,
+    englishCoverage: {
+      total: c.totalRepos,
+      withEnglish: withEn,
+      pct: Math.round((withEn / c.totalRepos) * 100),
+    },
+    top10ByStars: top,
+  };
+}


### PR DESCRIPTION
The 250-repo collection is now queryable straight from the terminal — no MCP client required. Adds a second bin, `aipulse`, alongside the MCP server, sharing the same query logic.

```bash
npx -p @aipulsegeorgia/mcp-server aipulse search "rag memory"
aipulse list --category coding --limit 10
aipulse get aider --lang both
aipulse stats
```

- `src/query.ts` — shared list/search/get/stats logic (DRY across MCP + CLI)
- `src/index.ts` — refactored to use query.ts (behaviour unchanged)
- `src/cli.ts` — commands categories/list/search/get/stats; flags -c/-n/--offset/-s/-l/--json
- `package.json` — second bin `aipulse`, build bundles cli.ts, `npm run cli`
- smoke-test — added CLI check to CI/prepublish
- README — CLI section + refreshed counts (250/14)

Verified: build ok, full smoke passes (MCP 5 tools + CLI stats), all CLI commands exercised live.

Generated with Claude Code