### PR TITLE
fix(assets): update stale counts (250→300 repos, 14→15 categories)

### DIFF
--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -119,12 +119,12 @@
   <g font-family="'Segoe UI', Arial, sans-serif" font-size="13">
     <!-- Repos -->
     <text x="80" y="296" text-anchor="middle">
-      <tspan fill="#00D0FF" font-weight="700" font-size="20">250</tspan>
+      <tspan fill="#00D0FF" font-weight="700" font-size="20">300</tspan>
       <tspan dx="6" fill="#B3B3B3">რეპო</tspan>
     </text>
     <!-- Categories -->
     <text x="220" y="296" text-anchor="middle">
-      <tspan fill="#A949DA" font-weight="700" font-size="20">14</tspan>
+      <tspan fill="#A949DA" font-weight="700" font-size="20">15</tspan>
       <tspan dx="6" fill="#B3B3B3">კატეგორია</tspan>
     </text>
     <!-- Tags -->

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # AI Pulse Georgia — MCP Server
 
-Query the [awesome-ai-pulse-georgia](https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia) curated collection (250 AI repos across 15 categories) directly from inside Claude Code, Cursor, Codex, Claude.ai, or any other [Model Context Protocol](https://modelcontextprotocol.io)–compatible client — or straight from your terminal with the bundled `aipulse` **CLI**.
+Query the [awesome-ai-pulse-georgia](https://github.com/tornikebolokadze1-cyber/awesome-ai-pulse-georgia) curated collection (300 AI repos across 15 categories) directly from inside Claude Code, Cursor, Codex, Claude.ai, or any other [Model Context Protocol](https://modelcontextprotocol.io)–compatible client — or straight from your terminal with the bundled `aipulse` **CLI**.
 
 Instead of opening GitHub and scrolling through a README, ask your AI assistant:
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -2,8 +2,8 @@
 /**
  * AI Pulse Georgia MCP Server
  *
- * Exposes the curated awesome-ai-pulse-georgia repo collection (250+ repos
- * across 14 categories) as MCP tools. Designed for stdio transport — usable
+ * Exposes the curated awesome-ai-pulse-georgia repo collection (300 repos
+ * across 15 categories) as MCP tools. Designed for stdio transport — usable
  * from Claude Code, Cursor, Codex, and any other MCP-compatible client.
  *
  * v0.2 — bilingual: every result includes editorial Georgian + GitHub-sourced


### PR DESCRIPTION
The banner SVG shown at the top of the README still displayed **250 რეპო / 14 კატეგორია**, and the MCP README + server header comment said 250 — all pre-growth numbers. The actual data (README tables, repos.json, graph.json, docs/data.js) has been at 300 repos / 15 categories since commit 2c2e3dd.

- assets/banner.svg: 250→300, 14→15
- mcp/README.md: "250 AI repos" → "300 AI repos"
- mcp/src/index.ts: header comment 250+/14 → 300/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated collection descriptions to reflect 300 AI repositories across 15 categories.
  * Kept MCP and CLI usage instructions unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->